### PR TITLE
Update org and rename project name (from Gnosis Protocol to CoW Protocol)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy GPv2 contracts
+name: Deploy CoW Protocol contracts
 
 on:
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# Gnosis Protocol V2
+# CoW Protocol
 
-This repository contains the Solidity smart contract code for the Gnosis Protocol version 2.
+This repository contains the Solidity smart contract code for the **CoW Protocol** (formerly know as **Gnosis Protocol**).
+
 For more documentation on how the protocol works on a smart contract level, see the [documentation pages](docs/index.md).
 
 ## Getting Started
@@ -57,7 +58,7 @@ yarn bench:trace
 ## Deployment
 
 Contracts deployment (including contract verification) is run automatically with GitHub Actions. The deployment process is triggered manually.
-Maintainers of this repository can deploy a new version of the contract in the "Actions" tab, "Deploy GPv2 contracts", "Run workflow". The target branch can be selected before running.
+Maintainers of this repository can deploy a new version of the contract in the "Actions" tab, "Deploy CoW Protocol contracts", "Run workflow". The target branch can be selected before running.
 A successful workflow results in a new PR asking to merge the deployment artifacts into the main branch.
 
 Contracts can also be deployed and verified manually as follows.

--- a/bench/fixture.ts
+++ b/bench/fixture.ts
@@ -151,7 +151,7 @@ export class BenchFixture {
   ) {}
 
   public static async create(): Promise<BenchFixture> {
-    debug("deploying GPv2 contracts");
+    debug("deploying CoW Protocol contracts");
     const deployment = await deployTestContracts();
     const {
       vaultAuthorizer,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 Below is a brief description of the smart contracts located in the `src/contracts/` directory:
 
-- `GPv2Settlement.sol`: The entrypoint for Gnosis Protocol V2; authenticated solvers call the `settle` function on this contract to perform batched settlements.
+- `GPv2Settlement.sol`: The entrypoint for CoW Protocol; authenticated solvers call the `settle` function on this contract to perform batched settlements.
 - `GPv2AllowListAuthentication.sol`: The allow list authentication contract is a simple `GPv2Authentication` implementation that manages a list of solvers that are authorized to perform settlements.
 - `GPv2VaultRelayer.sol`: The vault relayer is the contract users authorize on the Balancer v2 `Vault` enabling control of user balances; it is intentionally kept as a separate contracts so that SC interactions do not have access to this authorization.
 - `interfaces/`

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Gnosis Protocol V2 Smart Contracts
+# CoW Protocol Smart Contracts
 
 - [Architecture](architecture.md)
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@gnosis.pm/gp-v2-contracts",
+  "name": "@cowprotocol/contracts",
   "version": "1.1.2",
   "license": "LGPL-3.0-or-later",
   "scripts": {


### PR DESCRIPTION
This PR mainly changes the NPM org in the package.json so is in "cowprotocol" org instead of "gnosis.pm" one.

Additionally do the **minimal changes** to deprecate Gnosis Protocol v2 legacy name.

The scope of these minimal changes include just for some documentation (readme docs, GH workflows, etc), but it doesn't rename the contracts or comments inside it to avoid issues/breaking changes with dependant projects. 

We could consider doing it in future PRs, although i would suggest to do it only if we reiterate the protocol and deploy new contracts


NPM package has been published (v1.1.2)
https://www.npmjs.com/package/@cowprotocol/contracts
