### PR TITLE
Show if trade origin/destination is Balancer in decoder

### DIFF
--- a/src/tasks/decode.ts
+++ b/src/tasks/decode.ts
@@ -21,6 +21,7 @@ import {
   domain,
   computeOrderUid,
   decodeOrder,
+  OrderBalance,
 } from "../ts";
 
 import {
@@ -153,7 +154,13 @@ function displayTrade(
     flags,
     signature,
   } = trade;
-  const { kind, partiallyFillable, signingScheme } = decodeTradeFlags(flags);
+  const {
+    kind,
+    partiallyFillable,
+    signingScheme,
+    buyTokenBalance,
+    sellTokenBalance,
+  } = decodeTradeFlags(flags);
   let owner = null;
   let orderUid = null;
   if (domainSeparator !== null) {
@@ -187,8 +194,20 @@ function displayTrade(
       BigNumber.from(validTo).toNumber() * 1000,
     ).toISOString()} (${validTo.toString()})`,
   );
-  console.log(label(`Trade`), `sell ${prettyAmount(sellAmount, sellToken)}`);
-  console.log("      ", ` buy ${prettyAmount(buyAmount, buyToken, true)}`);
+  console.log(
+    label(`Trade`),
+    `sell ${prettyAmount(sellAmount, sellToken)}` +
+      (sellTokenBalance !== OrderBalance.ERC20
+        ? `, from Balancer ${sellTokenBalance} balance`
+        : ""),
+  );
+  console.log(
+    "      ",
+    ` buy ${prettyAmount(buyAmount, buyToken, true)}` +
+      (buyTokenBalance !== OrderBalance.ERC20
+        ? `, to Balancer ${buyTokenBalance} balance`
+        : ""),
+  );
   console.log("      ", ` fee ${prettyAmount(feeAmount, sellToken)}`);
   if (partiallyFillable) {
     console.log(


### PR DESCRIPTION
The decoder currently doesn't show the source of an order's sell tokens or the destination of the buy token. This PR makes this parameter visible.

### Test Plan

Decode an example transaction and look at how a trade is decoded:

```
$ npx hardhat decode --network mainnet --txhash 0xc8c13970e559d1eeeebbb3a776b2e611a20bbbb0aae78c0a42dcfa0ef6a1e0d3 
<snip>
=== Trades ===
Order: SELL order, valid until 2022-04-26T07:23:22.000Z (1650957802)
Trade: sell 1.781758973781093723 NATION (0), from Balancer external balance
        buy 2.003912157768758724  native token  (1)
        fee 0.002714559755776222 NATION (0)
Owner: 0x955a16Ef3098b8D4B8693fd65725Dc5D46926C30
Receiver: 0x955a16Ef3098b8D4B8693fd65725Dc5D46926C30
AppData: 0xe9f29ae547955463ed535162aefee525d8d309571a2b18bc26086c8c35d781eb
Signature (eip-712): 0x0aab8e3fb3f5a43115518a3b66e07961d1d47d65ea66a34f90e08dca1863a8ba5646a0ba4c55c8f3f8c9b08618edbfbf8f698e2ee27583c11a9e888b1841e3751b
OrderUid: 0x35a925b4ee9fb518392dba8368c5b67f351f45d2e4f08c0b89137e705144645c955a16ef3098b8d4b8693fd65725dc5d46926c3062679dea
<snip>
```