### PR TITLE
Add repo url to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@cowprotocol/contracts",
   "version": "1.3.0",
   "license": "LGPL-3.0-or-later",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cowprotocol/contracts.git"
+  },
   "scripts": {
     "deploy": "hardhat deploy",
     "verify:etherscan": "hardhat etherscan-verify --license LGPL-3.0 --force-license",


### PR DESCRIPTION
I noticed that the npm package page doesn't have a direct link to this repository (compare [our package](https://www.npmjs.com/package/@cowprotocol/contracts) to [for example this package](https://www.npmjs.com/package/@gnosis.pm/safe-deployments), top right info box). I personally find it handy to to see the original code from the package page.

In the past I've noticed that this link was taken from `package.json`, so in this PR I added the link there. It's also used by tools like Dependabot to get the changelog.

[Related docs.](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#repository)

### Test Plan

None.