### PR TITLE
Add Görli network

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -38,7 +38,7 @@ if (PK) {
 }
 
 if (
-  ["rinkeby", "mainnet"].includes(argv.network) &&
+  ["rinkeby", "goerli", "mainnet"].includes(argv.network) &&
   NODE_URL === undefined &&
   INFURA_KEY === undefined
 ) {
@@ -115,6 +115,11 @@ export default {
       url: `https://rinkeby.infura.io/v3/${INFURA_KEY}`,
       ...sharedNetworkConfig,
       chainId: 4,
+    },
+    goerli: {
+      url: `https://goerli.infura.io/v3/${INFURA_KEY}`,
+      ...sharedNetworkConfig,
+      chainId: 5,
     },
     xdai: {
       url: "https://xdai.poanetwork.dev",

--- a/src/tasks/decode/interaction/uniswap_like.ts
+++ b/src/tasks/decode/interaction/uniswap_like.ts
@@ -13,21 +13,27 @@ import { InteractionDecoder } from "./template";
 
 const ROUTERS: Record<string, Record<string, string>> = {
   rinkeby: {
-    // https://uniswap.org/docs/v2/smart-contracts/router02/#address (same as mainnet)
+    // https://docs.uniswap.org/protocol/V2/reference/smart-contracts/router-02 (same as mainnet)
     "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D": "Uniswap",
-    // https://dev.sushi.com/sushiswap/contracts#alternative-networks (same as xdai)
+    // https://dev.sushi.com/docs/Developers/Deployment Addresses (same as xdai)
+    "0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506": "Sushiswap",
+  },
+  goerli: {
+    // https://docs.uniswap.org/protocol/V2/reference/smart-contracts/router-02 (same as mainnet)
+    "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D": "Uniswap",
+    // https://dev.sushi.com/docs/Developers/Deployment Addresses (same as xdai)
     "0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506": "Sushiswap",
   },
   mainnet: {
-    // https://uniswap.org/docs/v2/smart-contracts/router02/#address (same as rinkeby)
+    // https://docs.uniswap.org/protocol/V2/reference/smart-contracts/router-02
     "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D": "Uniswap",
-    // https://dev.sushi.com/sushiswap/contracts#sushiv-2-router02
+    // https://dev.sushi.com/docs/Developers/Deployment Addresses
     "0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9F": "Sushiswap",
   },
   xdai: {
-    // https://wiki.1hive.org/projects/honeyswap/honeyswap-on-xdai-1#amm-contracts
+    // https://wiki.1hive.org/projects/honeyswap/honeyswap-on-xdai
     "0x1C232F01118CB8B424793ae03F870aa7D0ac7f77": "Honeyswap",
-    // https://dev.sushi.com/sushiswap/contracts#alternative-networks (same as rinkeby)
+    // https://dev.sushi.com/docs/Developers/Deployment Addresses
     "0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506": "Sushiswap",
   },
 };

--- a/src/tasks/ts/deployment.ts
+++ b/src/tasks/ts/deployment.ts
@@ -3,7 +3,7 @@ import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 import { ContractName } from "../../ts";
 
-const supportedNetworks = ["rinkeby", "xdai", "mainnet"] as const;
+const supportedNetworks = ["rinkeby", "goerli", "xdai", "mainnet"] as const;
 export type SupportedNetwork = typeof supportedNetworks[number];
 export function isSupportedNetwork(
   network: string,

--- a/src/tasks/ts/tokens.ts
+++ b/src/tasks/ts/tokens.ts
@@ -29,12 +29,14 @@ export const NATIVE_TOKEN_SYMBOL: Record<SupportedNetwork | "hardhat", string> =
     hardhat: "ETH",
     mainnet: "ETH",
     rinkeby: "ETH",
+    goerli: "ETH",
     xdai: "xDAI",
   };
 
 export const WRAPPED_NATIVE_TOKEN_ADDRESS: Record<SupportedNetwork, string> = {
   mainnet: WethNetworks.WETH9[1].address,
   rinkeby: WethNetworks.WETH9[4].address,
+  goerli: "0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6",
   xdai: "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d",
 };
 

--- a/src/tasks/ts/tui.ts
+++ b/src/tasks/ts/tui.ts
@@ -34,6 +34,8 @@ export function transactionUrl(
       return `https://etherscan.io/tx/${hash}`;
     case "rinkeby":
       return `https://rinkeby.etherscan.io/tx/${hash}`;
+    case "goerli":
+      return `https://goerli.etherscan.io/tx/${hash}`;
     case "xdai":
       return `https://blockscout.com/xdai/mainnet/tx/${hash}`;
     default:

--- a/src/tasks/ts/value.ts
+++ b/src/tasks/ts/value.ts
@@ -21,6 +21,11 @@ export const REFERENCE_TOKEN: Record<SupportedNetwork, ReferenceToken> = {
     decimals: 18,
     address: "0x5592ec0cfb4dbc12d3ab100b257153436a1f0fea",
   },
+  goerli: {
+    symbol: "DAI",
+    decimals: 18,
+    address: "0xdc31Ee1784292379Fbb2964b3B9C4124D8F89C60",
+  },
   mainnet: {
     symbol: "DAI",
     decimals: 18,


### PR DESCRIPTION
Adds Görli to the supported networks.

Note that the exchange contracts aren't deployed right now on Görli. In a follow-up PR I'm going to check out commit `d4e0fcd58367907bf1aff54d182222eeaee793dd` (to get deterministic addresses), add Görli to hardhat.config.ts, deploy the contracts manually, and open a PR with the deployment information.

### Test Plan

Compare the balance of [the zero address on Görli](https://goerli.etherscan.io/address/0x0000000000000000000000000000000000000000) with the output of:

```
$ export INFURA_KEY='your Infura key here'
$ yarn hardhat console --network goerli
> ethers.utils.formatEther(await ethers.provider.getBalance("0x0000000000000000000000000000000000000000"))
'1309.679886624943201035'
```
