### PR TITLE
Use less restrictive peer dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "prepack": "yarn build"
   },
   "peerDependencies": {
-    "ethers": "~5.4.0"
+    "ethers": "^5.4.0"
   },
   "devDependencies": {
     "@0x/contract-artifacts-v2": "npm:@0x/contract-artifacts@^2.2.2",


### PR DESCRIPTION
Closes #15 

It looks like the `ethers` `peerDependency` was unnecessarily strict. Specifically, `~5.4.0` means any version `>= 5.4.0` **and** `< 5.5.0` (see <. This is clearly wrong, because we have a `devDependency` on `5.5.2`, meaning what we use for CI doesn't match what we require in our `peerDependency` since `5.5.2 ∉ ^5.4.0`.

This PR changes the version of the `peerDependency` to be `^5.4.0`, meaning any version `>= 5.4.0` **and** `< 6.0.0`. This seems more correct, as `5.5.2 ∈ ^5.4.0`.

### Test Plan

Test out dependency versions on <https://semver.npmjs.com/>. CI.
