### PR TITLE
Update Node version in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 16.x
       - run: yarn --frozen-lockfile
       - run: yarn build
       - run: bash src/workflows/deploy.sh "automated-contract-deployment-${{github.run_number}}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@cowprotocol'
       - run: yarn --frozen-lockfile


### PR DESCRIPTION
We currently use Node version 14 in CI, which, while still maintained, will eventually be deprecated and is not actively developed ([info](https://nodejs.org/en/about/releases/)).
Moreover, I suspect that many people in the team, me included, are using Node 16, if not even 18.

This PR bumps up the Node version we use in CI.

### Test Plan

CI.
