### PR TITLE
Update Gnosis Chain RPC endpoint

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -122,7 +122,7 @@ export default {
       chainId: 5,
     },
     xdai: {
-      url: "https://xdai.poanetwork.dev",
+      url: "https://rpc.gnosischain.com",
       ...sharedNetworkConfig,
       chainId: 100,
     },


### PR DESCRIPTION
This PR updates the Gnosis Chain RPC endpoint to use rpc.gnosischain.com since the old xdaichain one is now deprecated.
See https://developers.gnosischain.com/for-developers/developer-resources/update-rpc-url.

