### PR TITLE
Fix comment in EIP-712 hash generation

### DIFF
--- a/src/contracts/libraries/GPv2Order.sol
+++ b/src/contracts/libraries/GPv2Order.sol
@@ -139,7 +139,7 @@ library GPv2Order {
         bytes32 structHash;
 
         // NOTE: Compute the EIP-712 order struct hash in place. As suggested
-        // in the EIP proposal, noting that the order struct has 10 fields, and
+        // in the EIP proposal, noting that the order struct has 12 fields, and
         // including the type hash `(12 + 1) * 32 = 416` bytes to hash.
         // <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md#rationale-for-encodedata>
         // solhint-disable-next-line no-inline-assembly

--- a/src/contracts/libraries/GPv2Order.sol
+++ b/src/contracts/libraries/GPv2Order.sol
@@ -140,7 +140,7 @@ library GPv2Order {
 
         // NOTE: Compute the EIP-712 order struct hash in place. As suggested
         // in the EIP proposal, noting that the order struct has 12 fields, and
-        // including the type hash `(12 + 1) * 32 = 416` bytes to hash.
+        // prefixing the type hash `(1 + 12) * 32 = 416` bytes to hash.
         // <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md#rationale-for-encodedata>
         // solhint-disable-next-line no-inline-assembly
         assembly {


### PR DESCRIPTION
An external team is working on implementing our signature scheme from scratch and helpfully pointed out a mistake in our documentation.

### Test Plan

Count the number of fields in the order struct and redo the math in the next line.