### PR TITLE
Add option to execute dry-run with custom origin in dump script

### DIFF
--- a/src/tasks/dump.ts
+++ b/src/tasks/dump.ts
@@ -880,6 +880,9 @@ const setupDumpTask: () => void = () =>
               }. Did you export a valid private key?`,
             );
           } else {
+            // The next lines are a bit hacky since a VoidSigner is not a JsonRpcSigner, but it's still good enough as
+            // it returns an error every time a signing request is made (which shouldn't happen in dry run). The only
+            // method missing from a JsonRpcSigner is sendTransaction, which would fail with an obscure error if called.
             signer = await SignerWithAddress.create(
               new VoidSigner(origin) as unknown as providers.JsonRpcSigner,
             );

--- a/src/tasks/dump.ts
+++ b/src/tasks/dump.ts
@@ -8,6 +8,8 @@ import {
   ContractTransaction,
   Signer,
   utils,
+  VoidSigner,
+  providers,
 } from "ethers";
 import { task, types } from "hardhat/config";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
@@ -866,16 +868,22 @@ const setupDumpTask: () => void = () =>
           hre.ethers.getSigners(),
           getDeployedContract("GPv2Settlement", hre),
         ]);
-        const signer =
+        let signer =
           origin === undefined
             ? signers[0]
             : signers.find((signer) => signer.address === origin);
         if (signer === undefined) {
-          throw new Error(
-            `No signer found${
-              origin === undefined ? "" : ` for address ${origin}`
-            }. Did you export a valid private key?`,
-          );
+          if (!dryRun) {
+            throw new Error(
+              `No signer found${
+                origin === undefined ? "" : ` for address ${origin}`
+              }. Did you export a valid private key?`,
+            );
+          } else {
+            signer = await SignerWithAddress.create(
+              new VoidSigner(origin) as unknown as providers.JsonRpcSigner,
+            );
+          }
         }
         console.log(`Using account ${signer.address}`);
 


### PR DESCRIPTION
For testing and debugging it's nice to be able to execute the dump script from an arbitrary address during dry run without exporting its private key. These changes make it possible.

The solution is a bit hacky since a `VoidSigner` is not a `JsonRpcSigner`, but it's still good enough as it returns an error every time a signing request is made (which shouldn't happen in dry run). The only method missing from a `JsonRpcSigner` is `sendTransaction`, which would fail with an obscure error if called. However, I don't think it's worth reworking our signers to accommodate this feature.

### Test Plan

Note that address `0x0...01` has some DAI. We can try to dump them:

```
$ npx hardhat dump \
  --network mainnet \
  --to-token 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 \
  --receiver 0xA03be496e67Ec29bC62F01a428683D7F9c204930 \
  --api-url "https://barn.api.cow.fi/mainnet" \
  --origin 0x0000000000000000000000000000000000000001 \
  --dry-run \
  0x6b175474e89094c44da98b954eedeac495271d0f
Using account 0x0000000000000000000000000000000000000001
List of dumped tokens:
 token address                              | symbol | needs allowance? | received amount (WETH) | dumped amount           | fee % 
--------------------------------------------+--------+------------------+------------------------+-------------------------+-------
 0x6b175474e89094c44da98b954eedeac495271d0f | DAI    | yes              |   3.616611234253228344 | 5597.963978833455292775 | 0.08  

Before creating the orders, a total of 1 allowances will be granted to the vault relayer.
The receiver address 0xA03be496e67Ec29bC62F01a428683D7F9c204930 will receive at least 3.616611234253228344 WETH from the tokens listed above.
```
