### PR TITLE
Fix displayed fee rounding in dump script

### DIFF
--- a/src/tasks/dump.ts
+++ b/src/tasks/dump.ts
@@ -737,7 +737,7 @@ export async function dump({
       )} ${toTokenName} to the receiver address ${
         receiver.address
       } will be submitted onchain. The transfer network fee corresponds to about ${
-        feePercent < 0.01 ? "< 0.01" : feePercent.toFixed(1)
+        feePercent < 0.01 ? "< 0.01" : feePercent.toFixed(2)
       }% of the withdrawn amount.`,
     );
     sumReceived = sumReceived.add(amount);


### PR DESCRIPTION
If the fee is between <0.1% and >0.01% then it's confusingly displayed to the user as 0.0%. This PR shows two decimals for consistency with `< 0.01`.

### Test Plan

None.