### PR TITLE
Fix computing ETH value of WETH token

### DIFF
--- a/src/tasks/ts/value.ts
+++ b/src/tasks/ts/value.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from "ethers";
 
-import { OrderKind } from "../../ts";
+import { BUY_ETH_ADDRESS, OrderKind } from "../../ts";
 import { Api } from "../../ts/api";
 import { SupportedNetwork } from "../ts/deployment";
 import {
@@ -74,12 +74,15 @@ export async function ethValue(
   network: SupportedNetwork,
   api: Api,
 ): Promise<BigNumber> {
-  if (isNativeToken(token)) {
+  if (
+    isNativeToken(token) ||
+    token.address == WRAPPED_NATIVE_TOKEN_ADDRESS[network] // todo: remove when services support selling weth for eth
+  ) {
     return amount;
   }
   return await api.estimateTradeAmount({
     sellToken: token.address,
-    buyToken: WRAPPED_NATIVE_TOKEN_ADDRESS[network], // todo: replace WETH address with BUY_ETH_ADDRESS when services support ETH estimates
+    buyToken: BUY_ETH_ADDRESS,
     amount,
     kind: OrderKind.SELL,
   });

--- a/test/tasks/dump.test.ts
+++ b/test/tasks/dump.test.ts
@@ -19,7 +19,6 @@ import {
   GetDumpInstructionInput,
   getDumpInstructions,
 } from "../../src/tasks/dump";
-import { SupportedNetwork } from "../../src/tasks/ts/deployment";
 import { ProviderGasEstimator } from "../../src/tasks/ts/gas";
 import { Erc20Token, isNativeToken } from "../../src/tasks/ts/tokens";
 import { BUY_ETH_ADDRESS, OrderKind } from "../../src/ts";
@@ -101,7 +100,7 @@ export function mockQuerySellingTokenForEth({
     .expects("estimateTradeAmount")
     .withArgs({
       sellToken: token,
-      buyToken: wrappedNativeToken,
+      buyToken: BUY_ETH_ADDRESS,
       kind: OrderKind.SELL,
       amount,
     })
@@ -121,14 +120,8 @@ async function handledRejection(error?: unknown) {
   return { rejection };
 }
 
-// The getDumpInstructions function depends on the network only to retrieve
-// the right weth address for the network, and even then this is only needed
-// because of an issue in the services where BUY_ETH_ADDRESS cannot be used
-// to get a price quote.
-// TODO: remove when BUY_ETH_ADDRESS is supported and implemented in price
-// quotes.
-const network = undefined as unknown as SupportedNetwork;
-const wrappedNativeToken = undefined as unknown as string;
+// Any network works for testing.
+const network = "mainnet";
 
 describe("getDumpInstructions", () => {
   let consoleLogOutput: unknown = undefined;


### PR DESCRIPTION
Closes #20.

Dumping WETH tokens for WETH isn't possible in current `main` as the script tries to estimate how much the amount is worth in ETH, which is not supported by the current API.

Here we add a check so that the original amount is returned if trying to estimate the value of WETH.

Also, we now use `BUY_ETH_ADDRESS` for estimating ETH prices as it's now supported (note that selling WETH for ETH is not supported and returns an error from the API, so the extra WETH logic is still needed).

### Test Plan

Note that the address `0x0...01` has (a little) WETH.
```
$ git merge dry-run-dump-from-origin # won't be needed after corresponding PR is merged
$ npx hardhat dump \
  --network mainnet \
  --origin 0x0000000000000000000000000000000000000001 \
  --to-token 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 \
  --receiver 0xA03be496e67Ec29bC62F01a428683D7F9c204930 \
  --api-url "https://barn.api.cow.fi/mainnet" \
  --dry-run \
  0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
Using account 0x0000000000000000000000000000000000000001
Ignored 0.00003822508255714 units of WETH (0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2), the transaction fee is too large compared to the balance (1449.17%).
Nothing to do.
```