### PR TITLE
Fix extra comma in type hash computation comment

### DIFF
--- a/src/contracts/libraries/GPv2Order.sol
+++ b/src/contracts/libraries/GPv2Order.sol
@@ -38,8 +38,8 @@ library GPv2Order {
     ///         "bytes32 appData," +
     ///         "uint256 feeAmount," +
     ///         "string kind," +
-    ///         "bool partiallyFillable" +
-    ///         "string sellTokenBalance" +
+    ///         "bool partiallyFillable," +
+    ///         "string sellTokenBalance," +
     ///         "string buyTokenBalance" +
     ///     ")"
     /// )


### PR DESCRIPTION
A typo in the comment noticed by @bh2smith [here](https://github.com/cowprotocol/ethflowcontract/pull/3#discussion_r950648389).

### Test Plan

Just to be sure, confirm that the type hash was computed as expected by comparing the computed hash with the new string with the one that appears in the contract:

```
$ npx hardhat console
> const s =      "Order(" +
         "address sellToken," +
         "address buyToken," +
         "address receiver," +
         "uint256 sellAmount," +
         "uint256 buyAmount," +
         "uint32 validTo," +
         "bytes32 appData," +
         "uint256 feeAmount," +
         "string kind," +
         "bool partiallyFillable," +
         "string sellTokenBalance," +
         "string buyTokenBalance" +
     ")"
undefined
> ethers.utils.id(s)
'0xd5a25ba2e97094ad7d83dc28a6572da797d6b3e7fc6663bd93efb789fc17e489'
```