### PR TITLE
Add a task to submit empty solution with just approvals

### DIFF
--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -2,6 +2,7 @@ import { setupCopyArtifactsTask } from "./artifacts";
 import { setupDecodeTask } from "./decode";
 import { setupDumpTask } from "./dump";
 import { setupPlaceOrderTask } from "./placeOrder";
+import { setupSetApprovalsTask } from "./setApprovals";
 import { setupSolversTask } from "./solvers";
 import { setupTenderlyTask } from "./tenderly";
 import { setupTransferOwnershipTask } from "./transferOwnership";
@@ -13,6 +14,7 @@ export function setupTasks(): void {
   setupDecodeTask();
   setupDumpTask();
   setupPlaceOrderTask();
+  setupSetApprovalsTask();
   setupSolversTask();
   setupTenderlyTask();
   setupTransferOwnershipTask();

--- a/src/tasks/setApprovals.ts
+++ b/src/tasks/setApprovals.ts
@@ -1,0 +1,116 @@
+import { promises as fs } from "fs";
+
+import "@nomiclabs/hardhat-ethers";
+import { Contract } from "ethers";
+import { task, types } from "hardhat/config";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+
+import { SettlementEncoder } from "../ts";
+
+import { createGasEstimator, gweiToWei } from "./ts/gas";
+import { prompt } from "./ts/tui";
+
+interface Approval {
+  spender: string;
+  token: string;
+}
+
+interface Args {
+  input: string;
+  dryRun: boolean;
+  gasInGwei: number;
+}
+
+async function setApprovals(
+  { input, dryRun, gasInGwei }: Args,
+  hre: HardhatRuntimeEnvironment,
+) {
+  // Instantiate Settlement Contract
+  const settlementDeployment = await hre.deployments.get("GPv2Settlement");
+  const settlement = new Contract(
+    settlementDeployment.address,
+    settlementDeployment.abi,
+  ).connect(hre.ethers.provider);
+  const [signer] = await hre.ethers.getSigners();
+
+  //Instantiate ERC20 ABI
+  const IERC20 = await hre.artifacts.readArtifact(
+    "src/contracts/interfaces/IERC20.sol:IERC20",
+  );
+  const token = new Contract(
+    hre.ethers.constants.AddressZero,
+    IERC20.abi,
+    hre.ethers.provider,
+  );
+
+  // Load approval list and encode interaction for each entry
+  const approvals: Approval[] = JSON.parse(await fs.readFile(input, "utf-8"));
+  const encoder = new SettlementEncoder({});
+  approvals.forEach((approval) => {
+    encoder.encodeInteraction({
+      target: approval.token,
+      callData: token.interface.encodeFunctionData("approve", [
+        approval.spender,
+        hre.ethers.constants.MaxUint256,
+      ]),
+    });
+  });
+  const finalSettlement = encoder.encodedSettlement({});
+  const gasEstimator = createGasEstimator(hre, {
+    blockNative: true,
+  });
+  const gasPrice =
+    gasInGwei > 0
+      ? {
+          maxFeePerGas: gweiToWei(gasInGwei),
+          maxPriorityFeePerGas: gweiToWei(gasInGwei),
+        }
+      : await gasEstimator.txGasPrice();
+
+  // settle the transaction
+  if (
+    !dryRun &&
+    (await prompt(hre, `Submit with gas price ${gasPrice.maxFeePerGas}?`))
+  ) {
+    const response = await settlement
+      .connect(signer)
+      .settle(...finalSettlement, gasPrice);
+    console.log(
+      "Transaction submitted to the blockchain. Waiting for acceptance in a block...",
+    );
+    const receipt = await response.wait(1);
+    console.log(
+      `Transaction successfully executed. Transaction hash: ${receipt.transactionHash}`,
+    );
+  } else {
+    const settlementData = settlement.interface.encodeFunctionData(
+      "settle",
+      finalSettlement,
+    );
+    console.log(settlementData);
+  }
+}
+
+const setupSetApprovalsTask: () => void = () => {
+  task(
+    "set-approvals",
+    "Given a file containing a list of tokens and spenders, sets allowances on behalf of the settlement contract",
+  )
+    .addPositionalParam<string>(
+      "input",
+      `A json file containing a list of entries with token and spender field`,
+    )
+    .addFlag(
+      "dryRun",
+      "Just simulate the settlement instead of executing the transaction on the blockchain.",
+    )
+    .addOptionalParam(
+      "gasInGwei",
+      "Fix a gas price instead of using the blockscout gas estimator",
+      0,
+      types.int,
+    )
+    .setAction(setApprovals);
+};
+
+export { setupSetApprovalsTask };

--- a/src/tasks/setApprovals.ts
+++ b/src/tasks/setApprovals.ts
@@ -1,7 +1,6 @@
 import { promises as fs } from "fs";
 
 import "@nomiclabs/hardhat-ethers";
-import { Contract } from "ethers";
 import { task, types } from "hardhat/config";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 

--- a/src/tasks/setApprovals.ts
+++ b/src/tasks/setApprovals.ts
@@ -98,7 +98,7 @@ const setupSetApprovalsTask: () => void = () => {
     )
     .addOptionalParam(
       "gasInGwei",
-      "Fix a gas price instead of using the blockscout gas estimator",
+      "Fix a gas price instead of using the native gas estimator",
       0,
       types.int,
     )

--- a/src/tasks/ts/gas.ts
+++ b/src/tasks/ts/gas.ts
@@ -97,6 +97,6 @@ export class BlockNativeGasEstimator implements IGasEstimator {
   }
 }
 
-function gweiToWei(amount: number): BigNumber {
+export function gweiToWei(amount: number): BigNumber {
   return ethers.utils.parseUnits(amount.toFixed(9), 9);
 }


### PR DESCRIPTION
This PR adds a new standalone task to create and submit an empty solution with just approvals. This is needed for some solvers that don't want to set approvals not as part of the settlement directly as this would lower the score of their solutions.

### Test Plan

Checked simulation in dryRun and then executed https://etherscan.io/tx/0x41f6daa22066c6689c67d4d10d08462a926c063c26e8fadda0aa628c950f1fca#eventlog
