### PR TITLE
Set max tip to 1.1

### DIFF
--- a/src/tasks/setApprovals.ts
+++ b/src/tasks/setApprovals.ts
@@ -54,7 +54,7 @@ async function setApprovals(
     gasInGwei > 0
       ? {
           maxFeePerGas: gweiToWei(gasInGwei),
-          maxPriorityFeePerGas: gweiToWei(gasInGwei),
+          maxPriorityFeePerGas: gweiToWei(1.1),
         }
       : await gasEstimator.txGasPrice();
 


### PR DESCRIPTION
Max priority fee was set to unreasonable high value.

Example: https://etherscan.io/tx/0xecbf9f6cb3d3a166e529c1aa29292e84f882296192a3f09cd3162d10a4dad676

