### PR TITLE
Use Quote API For Price Estimates

### DIFF
--- a/src/tasks/ts/value.ts
+++ b/src/tasks/ts/value.ts
@@ -1,4 +1,4 @@
-import { BigNumber, utils } from "ethers";
+import { BigNumber } from "ethers";
 
 import { BUY_ETH_ADDRESS, OrderKind } from "../../ts";
 import { Api } from "../../ts/api";
@@ -46,7 +46,7 @@ export async function usdValue(
   referenceToken: ReferenceToken,
   api: Api,
 ): Promise<BigNumber> {
-  return utils.getAddress(token) != utils.getAddress(referenceToken.address)
+  return `${token}`.toLowerCase() != referenceToken.address.toLowerCase()
     ? await api.estimateTradeAmount({
         sellToken: token,
         buyToken: referenceToken.address,

--- a/src/tasks/ts/value.ts
+++ b/src/tasks/ts/value.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from "ethers";
+import { BigNumber, utils } from "ethers";
 
 import { BUY_ETH_ADDRESS, OrderKind } from "../../ts";
 import { Api } from "../../ts/api";
@@ -46,12 +46,14 @@ export async function usdValue(
   referenceToken: ReferenceToken,
   api: Api,
 ): Promise<BigNumber> {
-  return await api.estimateTradeAmount({
-    sellToken: token,
-    buyToken: referenceToken.address,
-    amount,
-    kind: OrderKind.SELL,
-  });
+  return utils.getAddress(token) != utils.getAddress(referenceToken.address)
+    ? await api.estimateTradeAmount({
+        sellToken: token,
+        buyToken: referenceToken.address,
+        amount,
+        kind: OrderKind.SELL,
+      })
+    : amount;
 }
 
 export async function usdValueOfEth(

--- a/src/ts/api.ts
+++ b/src/ts/api.ts
@@ -1,4 +1,4 @@
-import { BigNumber, BigNumberish } from "ethers";
+import { BigNumber, BigNumberish, constants } from "ethers";
 import fetch, { RequestInit } from "node-fetch";
 
 import {
@@ -68,21 +68,23 @@ export interface CommonQuoteQuery {
   sellToken: string;
   buyToken: string;
   receiver?: string;
-  validTo: Timestamp;
-  appData: HashLike;
-  partiallyFillable: boolean;
+  validTo?: Timestamp;
+  appData?: HashLike;
+  partiallyFillable?: boolean;
   sellTokenBalance?: OrderBalance;
   buyTokenBalance?: OrderBalance;
   from: string;
+  priceQuality?: QuotePriceQuality;
+}
+
+export enum QuotePriceQuality {
+  FAST = "fast",
+  OPTIMAL = "optimal",
 }
 
 export interface OrderDetailResponse {
   // Other fields are omitted until needed
   executedSellAmount: string;
-}
-export interface EstimateAmountResponse {
-  amount: string;
-  token: string;
 }
 export interface GetQuoteResponse {
   quote: Order;
@@ -161,20 +163,36 @@ async function estimateTradeAmount({
   amount,
   baseUrl,
 }: EstimateTradeAmountQuery & ApiCall): Promise<BigNumber> {
-  const response: EstimateAmountResponse = await call(
-    `markets/${sellToken}-${buyToken}/${apiKind(kind)}/${BigNumber.from(
-      amount,
-    ).toString()}`,
-    baseUrl,
+  const side =
+    kind == OrderKind.SELL
+      ? ({
+          kind: OrderKind.SELL,
+          sellAmountAfterFee: amount,
+        } as SellAmountAfterFee)
+      : ({
+          kind: OrderKind.BUY,
+          buyAmountAfterFee: amount,
+        } as BuyAmountAfterFee);
+  const { quote } = await getQuote(
+    { baseUrl },
+    {
+      from: constants.AddressZero,
+      sellToken,
+      buyToken,
+      priceQuality: QuotePriceQuality.FAST,
+      ...side,
+    },
   );
   // The services return the quote token used for the price. The quote token
   // is checked to make sure that the returned price meets our expectations.
-  if (response.token.toLowerCase() !== buyToken.toLowerCase()) {
+  if (quote.buyToken.toLowerCase() !== buyToken.toLowerCase()) {
     throw new Error(
-      `Price returned for sell token ${sellToken} uses an incorrect quote token (${response.token.toLowerCase()} instead of ${buyToken.toLowerCase()})`,
+      `Price returned for sell token ${sellToken} uses an incorrect quote token (${quote.buyToken.toLowerCase()} instead of ${buyToken.toLowerCase()})`,
     );
   }
-  return BigNumber.from(response.amount);
+  const estimatedAmount =
+    kind == OrderKind.SELL ? quote.buyAmount : quote.sellAmount;
+  return BigNumber.from(estimatedAmount);
 }
 
 async function placeOrder({

--- a/src/ts/api.ts
+++ b/src/ts/api.ts
@@ -163,16 +163,16 @@ async function estimateTradeAmount({
   amount,
   baseUrl,
 }: EstimateTradeAmountQuery & ApiCall): Promise<BigNumber> {
-  const side =
+  const side: BuyAmountAfterFee | SellAmountAfterFee =
     kind == OrderKind.SELL
-      ? ({
+      ? {
           kind: OrderKind.SELL,
           sellAmountAfterFee: amount,
-        } as SellAmountAfterFee)
-      : ({
+        }
+      : {
           kind: OrderKind.BUY,
           buyAmountAfterFee: amount,
-        } as BuyAmountAfterFee);
+        };
   const { quote } = await getQuote(
     { baseUrl },
     {


### PR DESCRIPTION
This PR fixes the withdraw script to use the `/quote` API instead of the deprecated `/markets` API (which no longer works!) for estimating prices.

Additionally, a small fix to USD price estimation was done to support withdrawing DAI from the settlement contract and avoid the error:

```
Warning: price retrieval failed for token DAI (0x6b175474e89094c44da98b954eedeac495271d0f): SameBuyAndSellToken (Buy token is the same as the sell token.)
```

### Test Plan

Did this week's fee withdrawal with the script 🚀 - so tested in prod.
