### PR TITLE
Bump version to 1.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/contracts",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "license": "LGPL-3.0-or-later",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bumps up version so that we can include the TS library changes of the last 8 months into the trading bod, most notably the updated API endpoints.

Ideally this is merged after #40, but if not I'll just bump the version number again.

After merging I'll trigger a release.

### Test Plan

None!