### PR TITLE
Adjust setApproval script to allow custom amounts

### DIFF
--- a/src/tasks/README.md
+++ b/src/tasks/README.md
@@ -1,0 +1,23 @@
+# Hardhat tasks
+
+Below a description of how to run some of the scripts in this folder:
+
+## setApprovals
+
+Set PK and NODE_URL env variables. Create a json with with a list of desired allowances (use 0 to revoke allowance) such as:
+
+```json
+[
+  {
+    "spender": "0x9008d19f58aabd9ed0d60971565aa8510560ab41",
+    "token": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+    "amount": "0"
+  }
+]
+```
+
+Then run
+
+```
+yarn hardhat set-approvals --network <network> --gas-in-gwei <gas_price> [--dry-run] <path to json>
+```

--- a/src/tasks/setApprovals.ts
+++ b/src/tasks/setApprovals.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from "fs";
 
 import "@nomiclabs/hardhat-ethers";
+import { BigNumber } from "ethers";
 import { task, types } from "hardhat/config";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
@@ -13,6 +14,7 @@ import { prompt } from "./ts/tui";
 interface Approval {
   spender: string;
   token: string;
+  amount: BigNumber;
 }
 
 interface Args {
@@ -42,7 +44,7 @@ async function setApprovals(
       target: approval.token,
       callData: token.encodeFunctionData("approve", [
         approval.spender,
-        hre.ethers.constants.MaxUint256,
+        approval.amount,
       ]),
     });
   });


### PR DESCRIPTION
As a follow up of the Tuesday incident, this will make it easier to generate files that can automatically revoke all approvals (by specifying amount 0) without having to manually change code.

For setting positive approvals this is not really an issue, as we were already using the highest amount by default before (so a solver submitting a json can not really change amounts for the worse)

### Test Plan

Run the unapprove script in dry run with valus
- 0
- "115792089237316195423570985008687907853269984665640564039457584007913129639935"

and simulate the transactions in tenderly [[1](https://dashboard.tenderly.co/gp-v2/solver-slippage/simulator/fb28d234-f3ea-49fa-a4bf-48ad77a07837), [2](https://dashboard.tenderly.co/gp-v2/solver-slippage/simulator/35169802-fee7-4e2e-8fe6-ab986319ae54)]
