### PR TITLE
feat: Add ethers as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,6 @@
     "fmt:sol": "prettier 'src/contracts/**/*.sol' -w",
     "prepack": "yarn build"
   },
-  "peerDependencies": {
-    "ethers": "^5.4.0"
-  },
   "devDependencies": {
     "@0x/contract-artifacts-v2": "npm:@0x/contract-artifacts@^2.2.2",
     "@gnosis.pm/safe-contracts": "^1.3.0",
@@ -62,7 +59,6 @@
     "eslint-plugin-no-only-tests": "^3.1.0",
     "eslint-plugin-prettier": "^4.2.1",
     "ethereum-waffle": "^3.4.0",
-    "ethers": "^5.5.2",
     "globby": "^11.0.4",
     "hardhat": "^2.8.3",
     "hardhat-deploy": "^0.7.3",
@@ -85,5 +81,8 @@
     "lib/",
     "networks.json",
     "src/"
-  ]
+  ],
+  "dependencies": {
+    "ethers": "5.5.2"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4400,22 +4400,7 @@ ethereumjs-wallet@0.6.5:
     utf8 "^3.0.0"
     uuid "^3.3.2"
 
-ethers@^4.0.32, ethers@^4.0.40:
-  version "4.0.48"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.48.tgz#330c65b8133e112b0613156e57e92d9009d8fbbe"
-  integrity sha512-sZD5K8H28dOrcidzx9f8KYh8083n5BexIO3+SbE4jK83L85FxtpXZBCQdXb8gkg+7sBqomcLhhkU7UHL+F7I2g==
-  dependencies:
-    aes-js "3.0.0"
-    bn.js "^4.4.0"
-    elliptic "6.5.3"
-    hash.js "1.1.3"
-    js-sha3 "0.5.7"
-    scrypt-js "2.0.4"
-    setimmediate "1.0.4"
-    uuid "2.0.1"
-    xmlhttprequest "1.8.0"
-
-ethers@^5.0.0, ethers@^5.0.1, ethers@^5.0.2, ethers@^5.0.25, ethers@^5.5.2:
+ethers@5.5.2, ethers@^5.0.0, ethers@^5.0.1, ethers@^5.0.2, ethers@^5.0.25:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.5.2.tgz#cd2e508c7342c44fa70392f722e8de8f2416489f"
   integrity sha512-EF5W+6Wwcu6BqVwpgmyR5U2+L4c1FQzlM/02dkZOugN3KF0cG9bzHZP+TDJglmPm2/IzCEJDT7KBxzayk7SAHw==
@@ -4450,6 +4435,21 @@ ethers@^5.0.0, ethers@^5.0.1, ethers@^5.0.2, ethers@^5.0.25, ethers@^5.5.2:
     "@ethersproject/wallet" "5.5.0"
     "@ethersproject/web" "5.5.1"
     "@ethersproject/wordlists" "5.5.0"
+
+ethers@^4.0.32, ethers@^4.0.40:
+  version "4.0.48"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.48.tgz#330c65b8133e112b0613156e57e92d9009d8fbbe"
+  integrity sha512-sZD5K8H28dOrcidzx9f8KYh8083n5BexIO3+SbE4jK83L85FxtpXZBCQdXb8gkg+7sBqomcLhhkU7UHL+F7I2g==
+  dependencies:
+    aes-js "3.0.0"
+    bn.js "^4.4.0"
+    elliptic "6.5.3"
+    hash.js "1.1.3"
+    js-sha3 "0.5.7"
+    scrypt-js "2.0.4"
+    setimmediate "1.0.4"
+    uuid "2.0.1"
+    xmlhttprequest "1.8.0"
 
 ethjs-unit@0.1.6:
   version "0.1.6"


### PR DESCRIPTION
We would like to upgrade to [ethers 6](https://docs.ethers.org/v6/migrating/) but having ethers 5 as a peer dependency is a blocker at the moment.

Would you consider adding ethers 5 as a dependency instead?