### PR TITLE
Methods for Order Cancellations

### DIFF
--- a/src/ts/order.ts
+++ b/src/ts/order.ts
@@ -75,11 +75,11 @@ export interface Order {
 /**
  * Gnosis Protocol v2 order cancellation data.
  */
-export interface OrderCancellation {
+export interface OrderCancellations {
   /**
    * The unique identifier of the order to be cancelled.
    */
-  orderUid: BytesLike;
+  orderUids: BytesLike[];
 }
 
 /**
@@ -166,7 +166,9 @@ export const ORDER_TYPE_FIELDS = [
 /**
  * The EIP-712 type fields definition for a Gnosis Protocol v2 order.
  */
-export const CANCELLATION_TYPE_FIELDS = [{ name: "orderUid", type: "bytes" }];
+export const CANCELLATIONS_TYPE_FIELDS = [
+  { name: "orderUids", type: "bytes[]" },
+];
 
 /**
  * The EIP-712 type hash for a Gnosis Protocol v2 order.
@@ -298,10 +300,24 @@ export function hashOrderCancellation(
   domain: TypedDataDomain,
   orderUid: BytesLike,
 ): string {
+  return hashOrderCancellations(domain, [orderUid]);
+}
+
+/**
+ * Compute the 32-byte signing hash for the specified order cancellations.
+ *
+ * @param domain The EIP-712 domain separator to compute the hash for.
+ * @param orderUids The unique identifiers of the orders to cancel.
+ * @return Hex-encoded 32-byte order digest.
+ */
+export function hashOrderCancellations(
+  domain: TypedDataDomain,
+  orderUids: BytesLike[],
+): string {
   return hashTypedData(
     domain,
-    { OrderCancellation: CANCELLATION_TYPE_FIELDS },
-    { orderUid },
+    { OrderCancellations: CANCELLATIONS_TYPE_FIELDS },
+    { orderUids },
   );
 }
 

--- a/src/ts/sign.ts
+++ b/src/ts/sign.ts
@@ -2,7 +2,7 @@ import { BytesLike, ethers, Signer } from "ethers";
 
 import {
   ORDER_TYPE_FIELDS,
-  CANCELLATION_TYPE_FIELDS,
+  CANCELLATIONS_TYPE_FIELDS,
   Order,
   normalizeOrder,
   hashTypedData,
@@ -185,8 +185,7 @@ export async function signOrder(
 }
 
 /**
- * Returns the signature for the Order Cancellation with the signing scheme encoded
- * into the signature.
+ * Returns the signature for cancelling an with the signing scheme.
  *
  * @param domain The domain to sign the cancellation.
  * @param orderUid The unique identifier of the order being cancelled.
@@ -201,14 +200,34 @@ export async function signOrderCancellation(
   owner: Signer,
   scheme: EcdsaSigningScheme,
 ): Promise<EcdsaSignature> {
+  return signOrderCancellations(domain, [orderUid], owner, scheme);
+}
+
+/**
+ * Returns the signature for cancelling orders by UID using the the signing
+ * scheme.
+ *
+ * @param domain The domain to sign the cancellation.
+ * @param orderUids The unique identifiers of the orders to cancel.
+ * @param owner The owner for the order used to sign.
+ * @param scheme The signing scheme to use. See {@link SigningScheme} for more
+ * details.
+ * @return Encoded signature including signing scheme for the cancellation.
+ */
+export async function signOrderCancellations(
+  domain: TypedDataDomain,
+  orderUids: BytesLike[],
+  owner: Signer,
+  scheme: EcdsaSigningScheme,
+): Promise<EcdsaSignature> {
   return {
     scheme,
     data: await ecdsaSignTypedData(
       scheme,
       owner,
       domain,
-      { OrderCancellation: CANCELLATION_TYPE_FIELDS },
-      { orderUid },
+      { OrderCancellations: CANCELLATIONS_TYPE_FIELDS },
+      { orderUids },
     ),
   };
 }

--- a/src/ts/sign.ts
+++ b/src/ts/sign.ts
@@ -185,7 +185,8 @@ export async function signOrder(
 }
 
 /**
- * Returns the signature for cancelling an with the signing scheme.
+ * Returns the signature for cancelling a single order with the specified
+ * signing scheme.
  *
  * @param domain The domain to sign the cancellation.
  * @param orderUid The unique identifier of the order being cancelled.
@@ -204,8 +205,8 @@ export async function signOrderCancellation(
 }
 
 /**
- * Returns the signature for cancelling orders by UID using the the signing
- * scheme.
+ * Returns the signature for cancelling multiple orders by UID with the
+ * specified signing scheme.
  *
  * @param domain The domain to sign the cancellation.
  * @param orderUids The unique identifiers of the orders to cancel.


### PR DESCRIPTION
In https://github.com/cowprotocol/services/pull/739 we introduced a new method in the backend for handling multiple order cancellations. With this change, we decided to deprecate the order `OrderCancellation` message and API endpoint.

This PR introduces new `{sign,hash}OrderCancellations` methods for signing and hashing (respectively) order cancellations for the new API introduced in the aforementioned PR. Additionally, the existing singular `{sign,hash}OrderCancellation` methods were re-implemented to use the new scheme. This way, the order cancellation signature methods included in this package will work with the intended API instead of the deprecated API.

Note that this is a breaking change.

### Test Plan

Existing unit tests for order cancellations continue to pass.
