### PR TITLE
Bump Node version to 18

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 16.x
+          node-version: 18.x
       - run: yarn --frozen-lockfile
       - run: yarn build
       - run: bash src/workflows/deploy.sh "automated-contract-deployment-${{github.run_number}}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@cowprotocol'
       - run: yarn --frozen-lockfile

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine3.13
+FROM node:18-alpine3.17
 
 # Create app directory
 WORKDIR /usr/src/app/


### PR DESCRIPTION
We use Node 14 when building the Docker image for this repo, which [causes CI to fail](https://github.com/cowprotocol/contracts/actions/runs/4676227785/jobs/8282347632) after the latest dependency updates.

Node 14 leaves maintenance mode this month (see [release schedule](https://nodejs.dev/en/about/releases/)) and is then technically unsupported. Version 16 will be unsupported by October this year as well. 
This PR switches all versions of Node in CI to 18.

### Test Plan

CI and `docker build -f src/docker/Dockerfile .`.