### PR TITLE
Reorganize functions in withdraw script

### DIFF
--- a/src/tasks/ts/oneinch_tokens.ts
+++ b/src/tasks/ts/oneinch_tokens.ts
@@ -1,0 +1,36 @@
+import axios from "axios";
+import { Contract } from "ethers";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+
+import { erc20Token, Erc20Token } from "./tokens";
+
+// https://api.1inch.exchange/swagger/ethereum/#/Tokens/TokensController_getTokens
+export type OneinchTokenList = Record<
+  string,
+  { symbol: string; decimals: number; address: string }
+>;
+export const ONEINCH_TOKENS: Promise<OneinchTokenList> = axios
+  .get("https://api.1inch.exchange/v3.0/1/tokens")
+  .then((response) => response.data.tokens)
+  .catch(() => {
+    console.log("Warning: unable to recover token list from 1inch");
+    return {};
+  });
+
+export async function fastTokenDetails(
+  address: string,
+  hre: HardhatRuntimeEnvironment,
+): Promise<Erc20Token | null> {
+  const oneinchTokens = await ONEINCH_TOKENS;
+  if (
+    hre.network.name === "mainnet" &&
+    oneinchTokens[address.toLowerCase()] !== undefined
+  ) {
+    const IERC20 = await hre.artifacts.readArtifact(
+      "src/contracts/interfaces/IERC20.sol:IERC20",
+    );
+    const contract = new Contract(address, IERC20.abi, hre.ethers.provider);
+    return { ...oneinchTokens[address.toLowerCase()], contract };
+  }
+  return erc20Token(address, hre);
+}

--- a/src/tasks/ts/tui.ts
+++ b/src/tasks/ts/tui.ts
@@ -2,6 +2,14 @@ import readline from "readline";
 
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
+// Only a single readline interface should be available at each point in time.
+// If more than one is created, then any input to stdin will be printed more
+// than once to stdout.
+export const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
 export async function prompt(
   { network }: HardhatRuntimeEnvironment,
   message: string,
@@ -11,10 +19,6 @@ export async function prompt(
     return true;
   }
 
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
   const response = await new Promise<string>((resolve) =>
     rl.question(`${message} (y/N) `, (response) => resolve(response)),
   );

--- a/src/tasks/ts/value.ts
+++ b/src/tasks/ts/value.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from "ethers";
+import { BigNumber, utils } from "ethers";
 
 import { BUY_ETH_ADDRESS, OrderKind } from "../../ts";
 import { Api } from "../../ts/api";
@@ -112,4 +112,24 @@ export function formatUsdValue(
   usdReference: ReferenceToken,
 ): string {
   return formatTokenValue(amount, usdReference.decimals, 2);
+}
+
+export function formatGasCost(
+  amount: BigNumber,
+  usdAmount: BigNumber,
+  network: SupportedNetwork,
+  usdReference: ReferenceToken,
+): string {
+  switch (network) {
+    case "mainnet": {
+      return `${utils.formatEther(amount)} ETH (${formatUsdValue(
+        usdAmount,
+        usdReference,
+      )} USD)`;
+    }
+    case "xdai":
+      return `${utils.formatEther(amount)} XDAI`;
+    default:
+      return `${utils.formatEther(amount)} ETH`;
+  }
 }

--- a/src/tasks/withdraw/messages.ts
+++ b/src/tasks/withdraw/messages.ts
@@ -1,0 +1,28 @@
+import { BigNumber, utils } from "ethers";
+
+import { displayName, Erc20Token, NativeToken } from "../ts/tokens";
+import { formatUsdValue, ReferenceToken } from "../ts/value";
+
+export function ignoredTokenMessage(
+  [token, amount]: [Erc20Token | NativeToken, BigNumber],
+  reason?: string,
+  asUsd?: [ReferenceToken, BigNumber],
+) {
+  const decimals = token.decimals ?? 18;
+  let message = `Ignored ${utils.formatUnits(
+    amount,
+    decimals,
+  )} units of ${displayName(token)}${
+    token.decimals === undefined
+      ? ` (no decimals specified in the contract, assuming ${decimals})`
+      : ""
+  }`;
+  if (asUsd !== undefined) {
+    const [usdReference, valueUsd] = asUsd;
+    message += ` with value ${formatUsdValue(valueUsd, usdReference)} USD`;
+  }
+  if (reason !== undefined) {
+    message += `, ${reason}`;
+  }
+  return message;
+}

--- a/src/tasks/withdraw/settle.ts
+++ b/src/tasks/withdraw/settle.ts
@@ -1,0 +1,54 @@
+import { Contract } from "ethers";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+
+import { EncodedSettlement } from "../../ts";
+import { IGasEstimator } from "../ts/gas";
+import { prompt } from "../ts/tui";
+
+import { isSigner, SignerOrAddress } from "./signer";
+
+export interface SubmitSettlementInput {
+  dryRun: boolean;
+  doNotPrompt?: boolean | undefined;
+  hre: HardhatRuntimeEnvironment;
+  settlementContract: Contract;
+  solver: SignerOrAddress;
+  requiredConfirmations?: number | undefined;
+  gasEstimator: IGasEstimator;
+  encodedSettlement: EncodedSettlement;
+}
+export async function submitSettlement({
+  dryRun,
+  doNotPrompt,
+  hre,
+  settlementContract,
+  solver,
+  requiredConfirmations,
+  gasEstimator,
+  encodedSettlement,
+}: SubmitSettlementInput) {
+  if (!isSigner(solver)) {
+    const settlementData = settlementContract.interface.encodeFunctionData(
+      "settle",
+      encodedSettlement,
+    );
+    console.log("Settlement transaction:");
+    console.log(`to:   ${settlementContract.address}`);
+    console.log(`data: ${settlementData}`);
+  } else if (
+    !dryRun &&
+    (doNotPrompt || (await prompt(hre, "Submit settlement?")))
+  ) {
+    console.log("Executing the withdraw transaction on the blockchain...");
+    const response = await settlementContract
+      .connect(solver)
+      .settle(...encodedSettlement, await gasEstimator.txGasPrice());
+    console.log(
+      "Transaction submitted to the blockchain. Waiting for acceptance in a block...",
+    );
+    const receipt = await response.wait(requiredConfirmations);
+    console.log(
+      `Transaction successfully executed. Transaction hash: ${receipt.transactionHash}`,
+    );
+  }
+}

--- a/src/tasks/withdraw/signer.ts
+++ b/src/tasks/withdraw/signer.ts
@@ -1,0 +1,26 @@
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+
+export type SignerOrAddress =
+  | SignerWithAddress
+  | { address: string; _isSigner: false };
+
+export async function getSignerOrAddress(
+  { ethers }: HardhatRuntimeEnvironment,
+  origin?: string,
+): Promise<SignerOrAddress> {
+  const signers = await ethers.getSigners();
+  const originAddress = ethers.utils.getAddress(origin ?? signers[0].address);
+  return (
+    signers.find(({ address }) => address === originAddress) ?? {
+      address: originAddress,
+      // Take advantage of the fact that all Ethers signers have `_isSigner` set
+      // to `true`.
+      _isSigner: false,
+    }
+  );
+}
+
+export function isSigner(solver: SignerOrAddress): solver is SignerWithAddress {
+  return solver._isSigner;
+}

--- a/src/ts/api.ts
+++ b/src/ts/api.ts
@@ -17,6 +17,8 @@ export enum Environment {
   Prod,
 }
 
+export const LIMIT_CONCURRENT_REQUESTS = 5;
+
 export function apiUrl(environment: Environment, network: string): string {
   switch (environment) {
     case Environment.Dev:
@@ -41,6 +43,7 @@ export interface EstimateTradeAmountQuery {
 export interface PlaceOrderQuery {
   order: Order;
   signature: Signature;
+  from?: string;
 }
 export interface GetExecutedSellAmountQuery {
   uid: string;
@@ -199,6 +202,7 @@ async function placeOrder({
   order,
   signature,
   baseUrl,
+  from,
 }: PlaceOrderQuery & ApiCall): Promise<string> {
   const normalizedOrder = normalizeOrder(order);
   return await call("orders", baseUrl, {
@@ -216,6 +220,7 @@ async function placeOrder({
       signature: encodeSignatureData(signature),
       signingScheme: apiSigningScheme(signature.scheme),
       receiver: normalizedOrder.receiver,
+      from,
     }),
     headers: { "Content-Type": "application/json" },
   });


### PR DESCRIPTION
Moves around and slightly changes parameters of the code related to the withdraw script, making them available for reuse.
There is no change in behavior for any of the existing scripts.

### Test Plan

Existing unit tests.