### PR TITLE
Account for fee slippage

### DIFF
--- a/src/tasks/dump.ts
+++ b/src/tasks/dump.ts
@@ -67,7 +67,9 @@ interface DumpInstruction {
   needsAllowance: boolean;
 }
 
-interface Quote {
+export interface Quote {
+  sellToken: string;
+  buyToken: string;
   sellAmount: BigNumber;
   buyAmount: BigNumber;
   feeAmount: BigNumber;
@@ -336,10 +338,13 @@ export async function getQuote({
   api,
 }: QuoteInput): Promise<Quote | null> {
   let quote;
+  const buyTokenAddress = isNativeToken(buyToken)
+    ? BUY_ETH_ADDRESS
+    : buyToken.address;
   try {
     const quotedOrder = await api.getQuote({
       sellToken: sellToken.address,
-      buyToken: isNativeToken(buyToken) ? BUY_ETH_ADDRESS : buyToken.address,
+      buyToken: buyTokenAddress,
       validTo,
       appData: APP_DATA,
       partiallyFillable: false,
@@ -348,6 +353,8 @@ export async function getQuote({
       sellAmountBeforeFee,
     });
     quote = {
+      sellToken: sellToken.address,
+      buyToken: buyTokenAddress,
       sellAmount: BigNumber.from(quotedOrder.quote.sellAmount),
       buyAmount: buyAmountWithSlippage(
         quotedOrder.quote.buyAmount,


### PR DESCRIPTION
Implements a [review comment](https://github.com/cowprotocol/contracts/pull/51#discussion_r1206422107) by @nlordell.

This PR adds a parameter, `feeSlippageBps`, that can be used to account for gas price increases when submitting the order.

### Test Plan

<details><summary>Try out the script with different values of `feeSlippageBps` and notice that the output values approximately scale as expected with the extra fees .</summary>


```
$  cat <<EOF >tokens-goerli.txt
0x5a98fcbea516cf06857215779fd812ca3bef1b32
0xf16e81dce15b08f326220742020379b855b87df9
0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48
0xba100000625a3754423978a60c9317c58a424e3d
0xd533a949740bb3306d119cc777fa900ba034cd52
EOF
$ # 10x
$ npx hardhat self-sell --network mainnet --origin 0x423cEc87f19F0778f549846e0801ee267a917935 --receiver 0xA03be496e67Ec29bC62F01a428683D7F9c204930 --min-value 900 --leftover 100 --to-token 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2 --max-fee-percent 100 $(cat ./tokens.txt) --dry-run --fee-slippage-bps 100000
Using account 0x423cEc87f19F0778f549846e0801ee267a917935
Amounts to sell:
 address                                    | value (USD) | balance          | sold amount      | symbol | buy amount (WETH) | fee % | needs allowance? 
--------------------------------------------+-------------+------------------+------------------+--------+-------------------+-------+------------------
 0x5a98fcbea516cf06857215779fd812ca3bef1b32 |     4648.15 |  2371.0727853622 |  2320.0617213056 | LDO    |      2.4360034836 | 2.97  | yes              
 0xf16e81dce15b08f326220742020379b855b87df9 |     4781.08 |  3656.7637395428 |  3580.2797114043 | ICE    |      2.4485005931 | 5.28  | yes              
 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48 |     5803.69 |  5804.2526540000 |  5704.2429980000 | USDC   |      3.0723557465 | 2.31  | yes              
 0xba100000625a3754423978a60c9317c58a424e3d |     9405.32 |  1828.5790596711 |  1809.1370950443 | BAL    |      5.0697149658 | 1.27  | yes              
 0xd533a949740bb3306d119cc777fa900ba034cd52 |    10977.44 | 13192.7658835110 | 13072.5852405577 | CRV    |      5.9386124347 | 1.01  | yes              

The settlement transaction will cost approximately 0.011591594337338925 ETH (20.97 USD) and will create 5 orders for an estimated value of 35115.69 USD. The proceeds (at least 18.9651872239 WETH) will be sent to 0xA03be496e67Ec29bC62F01a428683D7F9c204930.
$ # 100x
$ npx hardhat self-sell --network mainnet --origin 0x423cEc87f19F0778f549846e0801ee267a917935 --receiver 0xA03be496e67Ec29bC62F01a428683D7F9c204930 --min-value 900 --leftover 100 --to-token 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2 --max-fee-percent 100 $(cat ./tokens.txt) --dry-run --fee-slippage-bps 1000000
Using account 0x423cEc87f19F0778f549846e0801ee267a917935
Amounts to sell:
 address                                    | value (USD) | balance          | sold amount      | symbol | buy amount (WETH) | fee % | needs allowance? 
--------------------------------------------+-------------+------------------+------------------+--------+-------------------+-------+------------------
 0xf16e81dce15b08f326220742020379b855b87df9 |     4781.08 |  3656.7637395428 |  3580.2797114043 | ICE    |      1.4221853213 | 45.3  | yes              
 0x5a98fcbea516cf06857215779fd812ca3bef1b32 |     4648.15 |  2371.0727853622 |  2320.0617213056 | LDO    |      1.8867876240 | 24.92 | yes              
 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48 |     5803.69 |  5804.2526540000 |  5704.2429980000 | USDC   |      2.5288032004 | 19.65 | yes              
 0xba100000625a3754423978a60c9317c58a424e3d |     9405.32 |  1828.5790596711 |  1809.1370950443 | BAL    |      4.6021549004 | 10.38 | yes              
 0xd533a949740bb3306d119cc777fa900ba034cd52 |    10977.44 | 13192.7658835110 | 13072.5852405577 | CRV    |      5.4894271602 | 8.53  | yes              

The settlement transaction will cost approximately 0.011591594337338925 ETH (20.97 USD) and will create 5 orders for an estimated value of 35115.69 USD. The proceeds (at least 15.9293582065 WETH) will be sent to 0xA03be496e67Ec29bC62F01a428683D7F9c204930
$ # 1000x
$ npx hardhat self-sell --network mainnet --origin 0x423cEc87f19F0778f549846e0801ee267a917935 --receiver 0xA03be496e67Ec29bC62F01a428683D7F9c204930 --min-value 900 --leftover 100 --to-token 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2 --max-fee-percent 100 $(cat ./tokens.txt) --dry-run --fee-slippage-bps 10000000
Using account 0x423cEc87f19F0778f549846e0801ee267a917935
Ignored 5804.252654 units of USDC (0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48) with value 5803.69 USD, adjusting order for fee slippage requires more than what is obtained from selling
Ignored 13192.765883511028288825 units of CRV (0xd533a949740bb3306d119cc777fa900ba034cd52) with value 10977.44 USD, adjusting order for fee slippage requires more than what is obtained from selling
Ignored 1828.579059671129751121 units of BAL (0xba100000625a3754423978a60c9317c58a424e3d) with value 9411.70 USD, adjusting order for fee slippage requires more than what is obtained from selling
Ignored 3656.763739542895578478 units of ICE (0xf16e81dce15b08f326220742020379b855b87df9) with value 4781.08 USD, adjusting order for fee slippage requires more than what is obtained from selling
Ignored 2371.072785362211404914 units of LDO (0x5a98fcbea516cf06857215779fd812ca3bef1b32) with value 4644.73 USD, adjusting order for fee slippage requires more than what is obtained from selling
Nothing to do.
```
</details>