### PR TITLE
[Easy] correct API response types

### DIFF
--- a/src/ts/api.ts
+++ b/src/ts/api.ts
@@ -92,7 +92,8 @@ export interface OrderDetailResponse {
 export interface GetQuoteResponse {
   quote: Order;
   from: string;
-  expirationDate: Timestamp;
+  expiration: Timestamp;
+  id?: number;
 }
 
 export interface ApiError {


### PR DESCRIPTION
Quote response contains expiration instead of expirationDate and also contains a quote ID, cf: https://api.cow.fi/docs/#/default/post_api_v1_quote
