### PR TITLE
Use Ethplorers addressInfo API to fetch token holders

### DIFF
--- a/src/tasks/selfSell.ts
+++ b/src/tasks/selfSell.ts
@@ -59,8 +59,8 @@ import { BalanceOutput, getAmounts } from "./withdraw";
 import { ignoredTokenMessage } from "./withdraw/messages";
 import { submitSettlement } from "./withdraw/settle";
 import { getSignerOrAddress, SignerOrAddress } from "./withdraw/signer";
-import { getAllTradedTokens } from "./withdraw/traded_tokens";
 import { getTokensWithBalanceAbove } from "./withdraw/token_balances";
+import { getAllTradedTokens } from "./withdraw/traded_tokens";
 
 interface DisplayOrder {
   symbol: string;
@@ -905,7 +905,13 @@ const setupSelfSellTask: () => void = () =>
           throw new Error("Order validity too large");
         }
 
-        const tokens = (await getTokensWithBalanceAbove(minValue, settlementDeployment.address)).filter((token) => token != toToken);
+        // Exclude the toToken if needed, as we can not sell it for itself (buyToken is not allowed to equal sellToken)
+        const tokens = (
+          await getTokensWithBalanceAbove(
+            minValue,
+            settlementDeployment.address,
+          )
+        ).filter((token) => token != toToken);
 
         await selfSell({
           solver,

--- a/src/tasks/selfSell.ts
+++ b/src/tasks/selfSell.ts
@@ -60,6 +60,7 @@ import { ignoredTokenMessage } from "./withdraw/messages";
 import { submitSettlement } from "./withdraw/settle";
 import { getSignerOrAddress, SignerOrAddress } from "./withdraw/signer";
 import { getAllTradedTokens } from "./withdraw/traded_tokens";
+import { getTokensWithBalanceAbove } from "./withdraw/token_balances";
 
 interface DisplayOrder {
   symbol: string;
@@ -853,10 +854,6 @@ const setupSelfSellTask: () => void = () =>
       "blocknativeGasPrice",
       "Use BlockNative gas price estimates for transactions.",
     )
-    .addOptionalVariadicPositionalParam(
-      "tokens",
-      "An optional subset of tokens to consider for selling (otherwise all traded tokens will be queried).",
-    )
     .addOptionalParam(
       "toToken",
       "All input tokens will be dumped to this token. If not specified, it defaults to the network's native token (e.g., ETH)",
@@ -874,7 +871,6 @@ const setupSelfSellTask: () => void = () =>
           validity,
           receiver: inputReceiver,
           dryRun,
-          tokens,
           apiUrl,
           blocknativeGasPrice,
         },
@@ -908,6 +904,8 @@ const setupSelfSellTask: () => void = () =>
         if (validity > MAX_ORDER_VALIDITY_SECONDS) {
           throw new Error("Order validity too large");
         }
+
+        const tokens = (await getTokensWithBalanceAbove(minValue, settlementDeployment.address)).filter((token) => token != toToken);
 
         await selfSell({
           solver,

--- a/src/tasks/withdraw/token_balances.ts
+++ b/src/tasks/withdraw/token_balances.ts
@@ -1,0 +1,36 @@
+import axios from "axios";
+
+interface AddressInfoResponse {
+  tokens: Token[]
+}
+
+interface Token {
+  tokenInfo: TokenInfo;
+  balance: number;
+}
+
+interface TokenInfo {
+  address: string;
+  decimals: number;
+  price: TokenPrice;
+}
+
+interface TokenPrice {
+  rate: number;
+}
+
+export async function getTokensWithBalanceAbove(minValueUsd: string, settlementContract: string) {
+  const response = await axios.get(`https://api.ethplorer.io/getAddressInfo/${settlementContract}?apiKey=freekey`);
+  if (response.status !== 200) {
+    console.log(`Error getting tokens from ETHplorer ${response}`)
+  }
+  const result = []
+  const data = response.data as AddressInfoResponse;
+  for (const token of data.tokens)  {
+    const tokenUsdValue = token.tokenInfo.price.rate * (token.balance / Math.pow(10, token.tokenInfo.decimals))
+    if (tokenUsdValue > parseInt(minValueUsd)) {
+      result.push(token.tokenInfo.address)
+    }
+  }
+  return result;
+}

--- a/src/tasks/withdraw/token_balances.ts
+++ b/src/tasks/withdraw/token_balances.ts
@@ -21,7 +21,9 @@ export async function getTokensWithBalanceAbove(
     `https://api.ethplorer.io/getAddressInfo/${settlementContract}?apiKey=freekey`,
   );
   if (response.status !== 200) {
-    console.error(`Error getting tokens from ETHplorer ${response}`);
+    throw new Error(
+      `Error getting tokens from ETHplorer ${response}`
+    );
   }
   const result = [];
   const data = response.data as AddressInfoResponse;

--- a/src/tasks/withdraw/token_balances.ts
+++ b/src/tasks/withdraw/token_balances.ts
@@ -1,35 +1,36 @@
 import axios from "axios";
 
 interface AddressInfoResponse {
-  tokens: Token[]
+  tokens: {
+    tokenInfo: {
+      address: string;
+      decimals: number;
+      price: {
+        rate: number;
+      };
+    };
+    balance: number;
+  }[];
 }
 
-interface Token {
-  tokenInfo: TokenInfo;
-  balance: number;
-}
-
-interface TokenInfo {
-  address: string;
-  decimals: number;
-  price: TokenPrice;
-}
-
-interface TokenPrice {
-  rate: number;
-}
-
-export async function getTokensWithBalanceAbove(minValueUsd: string, settlementContract: string) {
-  const response = await axios.get(`https://api.ethplorer.io/getAddressInfo/${settlementContract}?apiKey=freekey`);
+export async function getTokensWithBalanceAbove(
+  minValueUsd: string,
+  settlementContract: string,
+): Promise<string[]> {
+  const response = await axios.get(
+    `https://api.ethplorer.io/getAddressInfo/${settlementContract}?apiKey=freekey`,
+  );
   if (response.status !== 200) {
-    console.log(`Error getting tokens from ETHplorer ${response}`)
+    console.error(`Error getting tokens from ETHplorer ${response}`);
   }
-  const result = []
+  const result = [];
   const data = response.data as AddressInfoResponse;
-  for (const token of data.tokens)  {
-    const tokenUsdValue = token.tokenInfo.price.rate * (token.balance / Math.pow(10, token.tokenInfo.decimals))
+  for (const token of data.tokens) {
+    const tokenUsdValue =
+      token.tokenInfo.price.rate *
+      (token.balance / Math.pow(10, token.tokenInfo.decimals));
     if (tokenUsdValue > parseInt(minValueUsd)) {
-      result.push(token.tokenInfo.address)
+      result.push(token.tokenInfo.address);
     }
   }
   return result;

--- a/src/tasks/withdraw/token_balances.ts
+++ b/src/tasks/withdraw/token_balances.ts
@@ -21,9 +21,7 @@ export async function getTokensWithBalanceAbove(
     `https://api.ethplorer.io/getAddressInfo/${settlementContract}?apiKey=freekey`,
   );
   if (response.status !== 200) {
-    throw new Error(
-      `Error getting tokens from ETHplorer ${response}`
-    );
+    throw new Error(`Error getting tokens from ETHplorer ${response}`);
   }
   const result = [];
   const data = response.data as AddressInfoResponse;


### PR DESCRIPTION
Instead of fetching the list of tokens to liquidate upon fee withdrawl manually from Etherscan, this PR introduces a programmatic way of doing so (h/t to @ahhda for discovering it). This means we no longer have to manually create a tokens.txt file and can in theory automatically propose the resulting transaction in the Safe using the proposer account (and send a message into the slack channel for signatures)

### Test Plan

Run https://www.notion.so/cownation/On-Call-d3e28c3b4af248b499010104642fb0c4?pvs=4#19428b1bf7414a22901ee4762e8c5c67 without the tokens.txt file
