### PR TITLE
Fix CD by pinning older docker image

### DIFF
--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine3.17
+FROM node:18.15-alpine3.17
 
 # Create app directory
 WORKDIR /usr/src/app/


### PR DESCRIPTION
When currently building the docker image of the contract, we are not including any artefacts, which - when running any hardhat script - yields the following error:

```
HardhatError: HH700: Artifact for contract "src/contracts/interfaces/IERC20.sol:IERC20" not found. 
```

When looking at the build history we can see a subtle difference between a build [that is working](https://github.com/cowprotocol/contracts/actions/runs/5974729999/job/16209505930#step:5:253) and [one that isn't](https://github.com/cowprotocol/contracts/actions/runs/5975825913/job/16212645253#step:5:248):

```
#11 0.750 $ hardhat compile --force
#11 4.073 Warning: unable to recover token list from 1inch
#11 4.364 Downloading compiler 0.7.6
#11 4.826 Downloading compiler 0.7.6
**#11 17.88 Compiled 58 Solidity files successfully**
#11 18.27 $ tsc && tsc -p tsconfig.lib.esm.json && tsc -p tsconfig.lib.commonjs.json
```

vs

```
#11 0.860 $ hardhat compile --force
#11 4.335 Warning: unable to recover token list from 1inch
#11 4.646 Downloading compiler 0.7.6
#11 5.211 $ tsc && tsc -p tsconfig.lib.esm.json && tsc -p tsconfig.lib.commonjs.json
```

The latter doesn't seem to compile any artefacts. According to https://github.com/NomicFoundation/hardhat/issues/3877 this is due to a URL parser behavior change in Node 18.16 that can lead to silent Download failures. It's still no entirely clear to me why it sometimes works (maybe because of some intermittent error)

### Test Plan

I hope this works, or at least tells us why the files are not being compiled
