### PR TITLE
Log to stdErr and rethrow if selfSell script fails

### DIFF
--- a/src/tasks/selfSell.ts
+++ b/src/tasks/selfSell.ts
@@ -772,11 +772,11 @@ export async function selfSell(input: SelfSellInput): Promise<string[] | null> {
   try {
     ({ orders, finalSettlement } = await prepareOrders(input));
   } catch (error) {
-    console.log(
+    console.error(
       "Script failed execution but no irreversible operations were performed",
     );
-    console.log(error);
-    return null;
+    console.error(error);
+    throw error;
   }
 
   if (finalSettlement === null) {


### PR DESCRIPTION
Execution failed [today](https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/r/s/2QjIc) and we didn't get alerted :-( 

This is because we silently swallow errors when preparing the orders. This script makes it so that we re-throw and log the error to stderr.
