### PR TITLE
Favor nonce from Safe Multisig api

### DIFF
--- a/src/tasks/selfSell.ts
+++ b/src/tasks/selfSell.ts
@@ -899,10 +899,7 @@ const setupSelfSellTask: () => void = () =>
       "blocknativeGasPrice",
       "Use BlockNative gas price estimates for transactions.",
     )
-    .addOptionalParam(
-      "toToken",
-      "All input tokens will be dumped to this token. If not specified, it defaults to the network's native token (e.g., ETH)",
-    )
+    .addParam("toToken", "All input tokens will be dumped to this token.")
     .addFlag(
       "safe",
       "Whether the solver is a Safe and the script should propose the transaction to the Safe UI instead of sending a transaction directly",

--- a/src/tasks/withdraw/safe.ts
+++ b/src/tasks/withdraw/safe.ts
@@ -48,7 +48,7 @@ export async function proposeTransaction(
   try {
     nonce = await recommendedNonce(chainId, authoringSafe);
   } catch {
-    console.log("Unable to determine recommended nonce");
+    console.log("Unable to determine recommended nonce, using current one");
     nonce = undefined;
   }
 


### PR DESCRIPTION
If there is a pending transaction in the Safe, the self-sell script overwrites it when creating the `settle` transaction.
With these changes, the created transaction will use the nonce that is recommended by the Safe API. This is the same nonce used by the interface to determine the nonce for the next transaction.

I also sneaked in a change in the parameters, since the script is not working unless `--to-token` is explicit.

### Test Plan

This is difficult to test as the script only works on mainnet (see #74).
I suggest to see that the api call returns the expected nonce.
For example, [0xA03be496e67Ec29bC62F01a428683D7F9c204930](https://app.safe.global/transactions/queue?safe=sep:0xA03be496e67Ec29bC62F01a428683D7F9c204930) is a Safe that right now has a pending transaction, and you can see that the API output is the expected one:

```sh
curl -X 'GET' \
  'https://safe-client.safe.global/v1/chains/11155111/safes/0xA03be496e67Ec29bC62F01a428683D7F9c204930/nonces' \
  -H 'accept: application/json'
{"currentNonce":10,"recommendedNonce":11}
```
