### PR TITLE
chore: remove coveralls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,3 @@ jobs:
       - run: yarn lint
       - run: yarn coverage
       - run: yarn test:ignored-in-coverage
-      - name: Coveralls
-        uses: coverallsapp/github-action@master
-        continue-on-error: true
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ npx hardhat tenderly:verify --network $NETWORK GPv2Contract=0xFeDbc87123caF39251
 
 This package additionally contains a `networks.json` file at the root with the address of each deployed contract as well the hash of the Ethereum transaction used to create the contract.
 
-## Test coverage [![Coverage Status](https://coveralls.io/repos/github/gnosis/gp-v2-contracts/badge.svg?branch=main)](https://coveralls.io/github/gnosis/gp-v2-contracts?branch=main)
+## Test coverage
 
 Test coverage can be checked with the command
 


### PR DESCRIPTION
## Description

Coveralls is noisy, since it started adding a message to each PR since a while ago.
We are also going to break full coverage while we migrate tests gradually from Hardhat to Foundry.
This PR removes Coveralls from this repo.

## Test Plan

See no new message on CI.

## Related Issues

#106