### PR TITLE
chore: bump pragma

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,11 +54,13 @@ jobs:
 
       - name: Run Forge build with ${{ matrix.profile }}
         # We always build with 0.7.6 to ensure that the project is compatible with the oldest version
-        run: >
-          ( forge --version ) &&
-          (( [ "${{ matrix.profile }}" == "solc-0.7.6" ] &&
-            forge build --use 0.7.6 --sizes --skip 'test/*' ) ||
-          ( forge build --sizes ))
+        run: |
+          forge --version
+          if [ "${{ matrix.profile }}" == "solc-0.7.6" ]; then
+            forge build --sizes --use 0.7.6 --skip 'test/*'
+          else
+            forge build --sizes
+          fi
         id: build
 
       - name: Run Forge tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        profile: [solc-0.7.6,solc-0.8.26]
+        profile: [solc-0.7.6,default]
 
     name: Foundry project
     runs-on: ubuntu-latest
@@ -58,12 +58,11 @@ jobs:
           ( forge --version ) &&
           (( [ "${{ matrix.profile }}" == "solc-0.7.6" ] &&
             forge build --use 0.7.6 --sizes --skip 'test/*' ) ||
-          ( [ "${{ matrix.profile }}" == "solc-0.8.26" ] &&
-            forge build --use 0.8.26 --sizes ))
+          ( forge build --sizes ))
         id: build
 
       - name: Run Forge tests
-        if: matrix.profile == 'solc-0.8.26'
+        if: matrix.profile != 'solc-0.7.6'
         run: |
           forge test -vvv
         id: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
   test:
     strategy:
       fail-fast: true
+      matrix:
+        profile: [solc-0.7.6,solc-0.8.26]
 
     name: Foundry project
     runs-on: ubuntu-latest
@@ -50,13 +52,18 @@ jobs:
         with:
           version: nightly
 
-      - name: Run Forge build
-        run: |
-          forge --version
-          forge build --sizes
+      - name: Run Forge build with ${{ matrix.profile }}
+        # We always build with 0.7.6 to ensure that the project is compatible with the oldest version
+        run: >
+          ( forge --version ) &&
+          (( [ "${{ matrix.profile }}" == "solc-0.7.6" ] &&
+            forge build --use 0.7.6 --sizes --skip 'test/*' ) ||
+          ( [ "${{ matrix.profile }}" == "solc-0.8.26" ] &&
+            forge build --use 0.8.26 --sizes ))
         id: build
 
       - name: Run Forge tests
+        if: matrix.profile == 'solc-0.8.26'
         run: |
           forge test -vvv
         id: test

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-  "solidity.packageDefaultDependenciesDirectory": ["node_modules", "lib"],
   "[solidity]": {
     "editor.defaultFormatter": "JuanBlanco.solidity"
   },

--- a/foundry.toml
+++ b/foundry.toml
@@ -4,7 +4,6 @@ out = "out"
 libs = ["node_modules", "lib"]
 
 # Compiler settings
-solc = "0.7.6"
 via_ir = false
 optimizer = true
 optimizer_runs = 1000000

--- a/src/contracts/GPv2AllowListAuthentication.sol
+++ b/src/contracts/GPv2AllowListAuthentication.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 
 import "./interfaces/GPv2Authentication.sol";
 import "./libraries/GPv2EIP1967.sol";

--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 pragma abicoder v2;
 
 import "./GPv2VaultRelayer.sol";
@@ -250,7 +250,7 @@ contract GPv2Settlement is GPv2Signing, ReentrancyGuard, StorageAccessible {
     function invalidateOrder(bytes calldata orderUid) external {
         (, address owner, ) = orderUid.extractOrderUidParams();
         require(owner == msg.sender, "GPv2: caller does not own order");
-        filledAmount[orderUid] = uint256(-1);
+        filledAmount[orderUid] = type(uint256).max;
         emit OrderInvalidated(owner, orderUid);
     }
 

--- a/src/contracts/GPv2VaultRelayer.sol
+++ b/src/contracts/GPv2VaultRelayer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 pragma abicoder v2;
 
 import "./interfaces/IERC20.sol";

--- a/src/contracts/interfaces/GPv2Authentication.sol
+++ b/src/contracts/interfaces/GPv2Authentication.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 
 /// @title Gnosis Protocol v2 Authentication Interface
 /// @author Gnosis Developers

--- a/src/contracts/interfaces/GPv2EIP1271.sol
+++ b/src/contracts/interfaces/GPv2EIP1271.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 
 library GPv2EIP1271 {
     /// @dev Value returned by a call to `isValidSignature` if the signature

--- a/src/contracts/interfaces/IERC20.sol
+++ b/src/contracts/interfaces/IERC20.sol
@@ -6,7 +6,7 @@
 // - Added `name`, `symbol` and `decimals` function declarations
 // <https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v3.4.0/contracts/token/ERC20/IERC20.sol>
 
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 
 /**
  * @dev Interface of the ERC20 standard as defined in the EIP.

--- a/src/contracts/interfaces/IVault.sol
+++ b/src/contracts/interfaces/IVault.sol
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 pragma abicoder v2;
 
 import "./IERC20.sol";

--- a/src/contracts/libraries/GPv2EIP1967.sol
+++ b/src/contracts/libraries/GPv2EIP1967.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 
 library GPv2EIP1967 {
     /// @dev The storage slot where the proxy administrator is stored, defined

--- a/src/contracts/libraries/GPv2Interaction.sol
+++ b/src/contracts/libraries/GPv2Interaction.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 
 /// @title Gnosis Protocol v2 Interaction Library
 /// @author Gnosis Developers

--- a/src/contracts/libraries/GPv2Order.sol
+++ b/src/contracts/libraries/GPv2Order.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 
 import "../interfaces/IERC20.sol";
 

--- a/src/contracts/libraries/GPv2SafeERC20.sol
+++ b/src/contracts/libraries/GPv2SafeERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 
 import "../interfaces/IERC20.sol";
 

--- a/src/contracts/libraries/GPv2Trade.sol
+++ b/src/contracts/libraries/GPv2Trade.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 
 import "../interfaces/IERC20.sol";
 import "../mixins/GPv2Signing.sol";

--- a/src/contracts/libraries/GPv2Transfer.sol
+++ b/src/contracts/libraries/GPv2Transfer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 pragma abicoder v2;
 
 import "../interfaces/IERC20.sol";

--- a/src/contracts/libraries/SafeCast.sol
+++ b/src/contracts/libraries/SafeCast.sol
@@ -8,7 +8,7 @@
 // - Convert to `type(*).*` notation
 // <https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v3.4.0/contracts/utils/SafeCast.sol>
 
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 
 /**
  * @dev Wrappers over Solidity's uintXX/intXX casting operators with added overflow

--- a/src/contracts/libraries/SafeMath.sol
+++ b/src/contracts/libraries/SafeMath.sol
@@ -8,7 +8,7 @@
 // - Added `ceilDiv` method
 // <https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v3.4.0/contracts/math/SafeMath.sol>
 
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 
 /**
  * @dev Wrappers over Solidity's arithmetic operations with added overflow

--- a/src/contracts/mixins/GPv2Signing.sol
+++ b/src/contracts/mixins/GPv2Signing.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 
 import "../interfaces/GPv2EIP1271.sol";
 import "../libraries/GPv2Order.sol";

--- a/src/contracts/mixins/Initializable.sol
+++ b/src/contracts/mixins/Initializable.sol
@@ -7,7 +7,7 @@
 // - Inlined `Address.isContract` implementation
 // <https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v3.4.0/contracts/proxy/Initializable.sol>
 
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 
 /**
  * @dev This is a base contract to aid in writing upgradeable contracts, or any kind of contract that will be deployed

--- a/src/contracts/mixins/ReentrancyGuard.sol
+++ b/src/contracts/mixins/ReentrancyGuard.sol
@@ -5,7 +5,7 @@
 // - Formatted code
 // <https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v3.4.0/contracts/utils/ReentrancyGuard.sol>
 
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 
 /**
  * @dev Contract module that helps prevent reentrant calls to a function.

--- a/src/contracts/mixins/StorageAccessible.sol
+++ b/src/contracts/mixins/StorageAccessible.sol
@@ -6,7 +6,7 @@
 // - Added linter directives to ignore low level call and assembly warnings
 // <https://github.com/gnosis/util-contracts/blob/v3.1.0-solc-7/contracts/StorageAccessible.sol>
 
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 
 /// @title ViewStorageAccessible - Interface on top of StorageAccessible base class to allow simulations from view functions
 interface ViewStorageAccessible {

--- a/src/contracts/reader/AllowListStorageReader.sol
+++ b/src/contracts/reader/AllowListStorageReader.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 
 /// @title Gnosis Protocol v2 Allow List Storage Reader
 /// @author Gnosis Developers

--- a/src/contracts/reader/GPv2TradeSimulator.sol
+++ b/src/contracts/reader/GPv2TradeSimulator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 pragma abicoder v2;
 
 import "../GPv2Settlement.sol";

--- a/src/contracts/reader/SettlementStorageReader.sol
+++ b/src/contracts/reader/SettlementStorageReader.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 pragma abicoder v2;
 
 /// @title Gnosis Protocol v2 Settlement Storage Reader

--- a/src/contracts/test/EventEmitter.sol
+++ b/src/contracts/test/EventEmitter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 
 contract EventEmitter {
     event Event(uint256 value, uint256 number);

--- a/src/contracts/test/GPv2AllowListAuthenticationTestInterface.sol
+++ b/src/contracts/test/GPv2AllowListAuthenticationTestInterface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 
 import "../GPv2AllowListAuthentication.sol";
 import "../libraries/GPv2EIP1967.sol";

--- a/src/contracts/test/GPv2AllowListAuthenticationV2.sol
+++ b/src/contracts/test/GPv2AllowListAuthenticationV2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 
 import "../GPv2AllowListAuthentication.sol";
 

--- a/src/contracts/test/GPv2InteractionTestInterface.sol
+++ b/src/contracts/test/GPv2InteractionTestInterface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 pragma abicoder v2;
 
 import "../libraries/GPv2Interaction.sol";

--- a/src/contracts/test/GPv2OrderTestInterface.sol
+++ b/src/contracts/test/GPv2OrderTestInterface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 pragma abicoder v2;
 
 import "../libraries/GPv2Order.sol";

--- a/src/contracts/test/GPv2SafeERC20TestInterface.sol
+++ b/src/contracts/test/GPv2SafeERC20TestInterface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 pragma abicoder v2;
 
 import "../interfaces/IERC20.sol";

--- a/src/contracts/test/GPv2SettlementTestInterface.sol
+++ b/src/contracts/test/GPv2SettlementTestInterface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 pragma abicoder v2;
 
 import "../GPv2Settlement.sol";

--- a/src/contracts/test/GPv2SigningTestInterface.sol
+++ b/src/contracts/test/GPv2SigningTestInterface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 pragma abicoder v2;
 
 import "../libraries/GPv2Order.sol";

--- a/src/contracts/test/GPv2TradeTestInterface.sol
+++ b/src/contracts/test/GPv2TradeTestInterface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 pragma abicoder v2;
 
 import "../libraries/GPv2Order.sol";

--- a/src/contracts/test/GPv2TransferTestInterface.sol
+++ b/src/contracts/test/GPv2TransferTestInterface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 pragma abicoder v2;
 
 import "../libraries/GPv2Transfer.sol";

--- a/src/contracts/test/NonPayable.sol
+++ b/src/contracts/test/NonPayable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 
 contract NonPayable {
     // solhint-disable-next-line no-empty-blocks, payable-fallback

--- a/src/contracts/test/NonStandardERC20.sol
+++ b/src/contracts/test/NonStandardERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 
 import "../libraries/SafeMath.sol";
 

--- a/src/contracts/test/SmartSellOrder.sol
+++ b/src/contracts/test/SmartSellOrder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 pragma abicoder v2;
 
 import "../interfaces/GPv2EIP1271.sol";

--- a/src/contracts/test/StateChangingERC1271.sol
+++ b/src/contracts/test/StateChangingERC1271.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 
 import "../interfaces/GPv2EIP1271.sol";
 

--- a/src/contracts/test/vendor/StorageAccessibleWrapper.sol
+++ b/src/contracts/test/vendor/StorageAccessibleWrapper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity >=0.7.0 <0.9.0;
+pragma solidity >=0.7.6 <0.9.0;
 
 import "../../mixins/StorageAccessible.sol";
 

--- a/test/TestNoOp.sol
+++ b/test/TestNoOp.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 pragma solidity >=0.7.6 <0.9.0;
 
 /// @dev No-op contract for start of forgifying contracts. Delete this!

--- a/test/TestNoOp.sol
+++ b/test/TestNoOp.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity ^0.7.6;
+pragma solidity >=0.7.6 <0.9.0;
 
 /// @dev No-op contract for start of forgifying contracts. Delete this!
 contract TestNoOp {


### PR DESCRIPTION
## Description

This PR bumps the pragma to support up-to-and-including solidity (`0.8.26`). This allows the foundry migration taking place to have tests written in solc `0.8.x`, reducing redundancy / effort with writing the associated test contracts.

It is important that the `bytecode` generated for production still be compliant with `0.7.6` (save for potential issues associated with the `metadata` hash appended by `solc`). To facilitate this, the `test` pipeline uses a multi-version matrix strategy to ensure that the contracts remain able to be built with `0.7.6`.

A minor miscellaneous patch is also included for VS Code's solidity configuration, reducing configuration size.

## Test Plan

1. Verify `test` CI/CD runs `0.7.6` and `0.8.26` matrices.
2. Verify that the `ci` CI/CD runs (`hardhat`) and completes successfully.

## Related Issues

Related: #106 