### PR TITLE
chore: check formatting on CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,36 @@
+name: Lint
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '**.sol'
+  push:
+    branches:
+      - main
+    paths:
+      - '**.sol'
+
+env:
+  FOUNDRY_PROFILE: ci
+
+jobs:
+  lint:
+    strategy:
+      fail-fast: true
+
+    name: Foundry project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Check Forge fmt
+        run: forge fmt --check
+        id: format

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,4 +3,5 @@
     "editor.defaultFormatter": "JuanBlanco.solidity"
   },
   "solidity.compileUsingRemoteVersion": "v0.7.6+commit.7338295f",
+  "solidity.formatter": "forge"
 }

--- a/foundry.toml
+++ b/foundry.toml
@@ -7,3 +7,10 @@ libs = ["node_modules", "lib"]
 via_ir = false
 optimizer = true
 optimizer_runs = 1000000
+
+[fmt]
+ignore = [
+  # We don't want to change the formatting of our main contracts until the
+  # migration to Foundry is concluded.
+  "src/contracts/**/*"
+]

--- a/test/TestNoOp.sol
+++ b/test/TestNoOp.sol
@@ -1,9 +1,0 @@
-// SPDX-License-Identifier: LGPL-3.0-or-later
-pragma solidity >=0.7.6 <0.9.0;
-
-/// @dev No-op contract for start of forgifying contracts. Delete this!
-contract TestNoOp {
-    function test_noOp(
-        
-    ) external pure {}
-}

--- a/test/TestNoOp.sol
+++ b/test/TestNoOp.sol
@@ -3,5 +3,7 @@ pragma solidity >=0.7.6 <0.9.0;
 
 /// @dev No-op contract for start of forgifying contracts. Delete this!
 contract TestNoOp {
-    function test_noOp() external pure {}
+    function test_noOp(
+        
+    ) external pure {}
 }


### PR DESCRIPTION
## Description

New GitHub action that enforces `forge fmt` formatting for files outside of `src/`.
No changes to source files were needed.

## Test Plan

CI. Try to break formatting locally and see that `forge fmt --check` catches that as long as it's not in `src/`.