### PR TITLE
chore: swap encoder and settlement library

### DIFF
--- a/test/helpers/SettlementEncoder.sol
+++ b/test/helpers/SettlementEncoder.sol
@@ -3,11 +3,14 @@ pragma solidity ^0.8.26;
 
 import {Vm} from "forge-std/Test.sol";
 
-import {GPv2Order, IERC20} from "src/contracts/libraries/GPv2Order.sol";
-import {GPv2Trade} from "src/contracts/libraries/GPv2Trade.sol";
-import {GPv2Signing} from "src/contracts/mixins/GPv2Signing.sol";
-import {GPv2Interaction} from "src/contracts/libraries/GPv2Interaction.sol";
-import {GPv2Settlement} from "src/contracts/GPv2Settlement.sol";
+import {
+    IERC20,
+    GPv2Order,
+    GPv2Trade,
+    GPv2Signing,
+    GPv2Interaction,
+    GPv2Settlement
+} from "src/contracts/GPv2Settlement.sol";
 
 import {Sign} from "test/libraries/Sign.sol";
 import {Trade} from "test/libraries/Trade.sol";

--- a/test/helpers/SettlementEncoder.sol
+++ b/test/helpers/SettlementEncoder.sol
@@ -51,7 +51,7 @@ contract SettlementEncoder {
 
     error InvalidOrderUidLength();
 
-    GPv2Settlement public settlement;
+    GPv2Settlement internal settlement;
     TokenRegistry internal tokenRegistry;
     GPv2Trade.Data[] public trades;
     GPv2Interaction.Data[][3] private interactions_;

--- a/test/helpers/SettlementEncoder.sol
+++ b/test/helpers/SettlementEncoder.sol
@@ -134,7 +134,7 @@ contract SettlementEncoder {
         }
     }
 
-    function toEncodedSettlement() public view returns (EncodedSettlement memory) {
+    function encode() public view returns (EncodedSettlement memory) {
         return EncodedSettlement({
             tokens: tokens(),
             clearingPrices: tokenRegistry.clearingPrices(),
@@ -143,7 +143,7 @@ contract SettlementEncoder {
         });
     }
 
-    function toEncodedSettlement(GPv2Interaction.Data[] memory setupInteractions)
+    function encode(GPv2Interaction.Data[] memory setupInteractions)
         public
         pure
         returns (EncodedSettlement memory)

--- a/test/helpers/SettlementEncoder.sol
+++ b/test/helpers/SettlementEncoder.sol
@@ -143,11 +143,7 @@ contract SettlementEncoder {
         });
     }
 
-    function encode(GPv2Interaction.Data[] memory setupInteractions)
-        public
-        pure
-        returns (EncodedSettlement memory)
-    {
+    function encode(GPv2Interaction.Data[] memory setupInteractions) public pure returns (EncodedSettlement memory) {
         return EncodedSettlement({
             tokens: new IERC20[](0),
             clearingPrices: new uint256[](0),

--- a/test/helpers/SwapEncoder.sol
+++ b/test/helpers/SwapEncoder.sol
@@ -62,7 +62,7 @@ contract SwapEncoder {
         encodeTrade(order, signature, executedAmount);
     }
 
-    function encodeSwap() public view returns (EncodedSwap memory) {
+    function encode() public view returns (EncodedSwap memory) {
         return EncodedSwap(steps, tokenRegistry.addresses(), trade);
     }
 

--- a/test/helpers/SwapEncoder.sol
+++ b/test/helpers/SwapEncoder.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+pragma solidity ^0.8.26;
+
+import {Vm} from "forge-std/Test.sol";
+
+import {IERC20} from "src/contracts/interfaces/IERC20.sol";
+import {IVault} from "src/contracts/interfaces/IVault.sol";
+import {GPv2Order} from "src/contracts/libraries/GPv2Order.sol";
+import {GPv2Trade} from "src/contracts/libraries/GPv2Trade.sol";
+import {GPv2Signing} from "src/contracts/mixins/GPv2Signing.sol";
+import {GPv2Settlement} from "src/contracts/GPv2Settlement.sol";
+
+import {Sign} from "../libraries/Sign.sol";
+import {Trade} from "../libraries/Trade.sol";
+
+import {TokenRegistry} from "./TokenRegistry.sol";
+
+contract SwapEncoder {
+    using Trade for GPv2Order.Data;
+    using Sign for Vm;
+
+    struct Swap {
+        bytes32 poolId;
+        IERC20 assetIn;
+        IERC20 assetOut;
+        uint256 amount;
+        bytes userData;
+    }
+
+    struct EncodedSwap {
+        IVault.BatchSwapStep[] swaps;
+        IERC20[] tokens;
+        GPv2Trade.Data trade;
+    }
+
+    GPv2Settlement internal settlement;
+    TokenRegistry internal tokenRegistry;
+    IVault.BatchSwapStep[] public steps;
+    GPv2Trade.Data public trade;
+
+    constructor(GPv2Settlement _settlement, TokenRegistry _tokenRegistry) {
+        settlement = _settlement;
+        tokenRegistry = _tokenRegistry;
+    }
+
+    function encodeSwapSteps(Swap[] memory swap) public {
+        for (uint256 i = 0; i < swap.length; i++) {
+            steps.push(toSwapStep(swap[i]));
+        }
+    }
+
+    function encodeTrade(GPv2Order.Data memory order, Sign.Signature memory signature, uint256 limitAmount) public {
+        if (limitAmount == 0) {
+            limitAmount = order.kind == GPv2Order.KIND_SELL ? order.buyAmount : order.sellAmount;
+        }
+        trade = order.toTrade(tokenRegistry.addresses(), signature, limitAmount);
+    }
+
+    function signEncodeTrade(
+        Vm vm,
+        Vm.Wallet memory owner,
+        GPv2Order.Data memory order,
+        GPv2Signing.Scheme signingScheme,
+        uint256 executedAmount
+    ) public {
+        Sign.Signature memory signature = vm.sign(owner, order, signingScheme, settlement.domainSeparator());
+        encodeTrade(order, signature, executedAmount);
+    }
+
+    function encodeSwap() public view returns (EncodedSwap memory) {
+        return EncodedSwap(steps, tokenRegistry.addresses(), trade);
+    }
+
+    function toSwapStep(Swap memory swap) private returns (IVault.BatchSwapStep memory step) {
+        step.poolId = swap.poolId;
+        step.assetInIndex = tokenRegistry.index(swap.assetIn);
+        step.assetOutIndex = tokenRegistry.index(swap.assetOut);
+        step.amount = swap.amount;
+        step.userData = swap.userData;
+    }
+}

--- a/test/helpers/SwapEncoder.sol
+++ b/test/helpers/SwapEncoder.sol
@@ -3,12 +3,7 @@ pragma solidity ^0.8.26;
 
 import {Vm} from "forge-std/Test.sol";
 
-import {IERC20} from "src/contracts/interfaces/IERC20.sol";
-import {IVault} from "src/contracts/interfaces/IVault.sol";
-import {GPv2Order} from "src/contracts/libraries/GPv2Order.sol";
-import {GPv2Trade} from "src/contracts/libraries/GPv2Trade.sol";
-import {GPv2Signing} from "src/contracts/mixins/GPv2Signing.sol";
-import {GPv2Settlement} from "src/contracts/GPv2Settlement.sol";
+import {IERC20, IVault, GPv2Order, GPv2Trade, GPv2Signing, GPv2Settlement} from "src/contracts/GPv2Settlement.sol";
 
 import {Sign} from "../libraries/Sign.sol";
 import {Trade} from "../libraries/Trade.sol";

--- a/test/libraries/Settlement.sol
+++ b/test/libraries/Settlement.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+pragma solidity ^0.8.26;
+
+import {GPv2Settlement} from "src/contracts/GPv2Settlement.sol";
+import {SettlementEncoder} from "../helpers/SettlementEncoder.sol";
+import {SwapEncoder} from "../helpers/SwapEncoder.sol";
+
+library Settlement {
+    function settle(GPv2Settlement settler, SettlementEncoder.EncodedSettlement memory settlement) internal {
+        settler.settle(settlement.tokens, settlement.clearingPrices, settlement.trades, settlement.interactions);
+    }
+
+    function swap(GPv2Settlement settler, SwapEncoder.EncodedSwap memory _swap) internal {
+        settler.swap(_swap.swaps, _swap.tokens, _swap.trade);
+    }
+}

--- a/test/libraries/Sign.sol
+++ b/test/libraries/Sign.sol
@@ -3,9 +3,7 @@ pragma solidity ^0.8.26;
 
 import {Vm} from "forge-std/Test.sol";
 
-import {GPv2Order} from "src/contracts/libraries/GPv2Order.sol";
-import {GPv2Trade} from "src/contracts/libraries/GPv2Trade.sol";
-import {GPv2Signing, EIP1271Verifier} from "src/contracts/mixins/GPv2Signing.sol";
+import {GPv2Order, GPv2Trade, GPv2Signing, EIP1271Verifier} from "src/contracts/mixins/GPv2Signing.sol";
 
 import {Bytes} from "./Bytes.sol";
 

--- a/test/libraries/Trade.sol
+++ b/test/libraries/Trade.sol
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 pragma solidity ^0.8.26;
 
-import {IERC20} from "src/contracts/interfaces/IERC20.sol";
-import {GPv2Signing} from "src/contracts/mixins/GPv2Signing.sol";
-import {GPv2Order} from "src/contracts/libraries/GPv2Order.sol";
-import {GPv2Trade} from "src/contracts/libraries/GPv2Trade.sol";
+import {IERC20, GPv2Order, GPv2Trade, GPv2Signing} from "src/contracts/mixins/GPv2Signing.sol";
 import {Sign} from "./Sign.sol";
 import {Order} from "./Order.sol";
 


### PR DESCRIPTION
## Description

This PR follows on from #163, including a `SwapEncoder`, and `Settlement` helper library. In completing the encoders, the main encoding functions have converged on `encode` as a generic term (inheriting context from the caller).

Additionally, imports across the libraries are cleaned.

## Test Plan

1. Review code and contrast with `ts` libraries.

## Related Issues

Closes #113 