### PR TITLE
chore: reorganize reader files

### DIFF
--- a/test/reader/StorageAccessible.t.sol
+++ b/test/reader/StorageAccessible.t.sol
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-
-pragma solidity >=0.7.6 <0.9.0;
-pragma abicoder v2;
+pragma solidity ^0.8.0;
 
 import {Test, Vm} from "forge-std/Test.sol";
-import {StorageAccessibleWrapper, ExternalStorageReader} from "test/src/vendor/StorageAccessibleWrapper.sol";
+import {StorageAccessibleWrapper, ExternalStorageReader} from "./StorageAccessibleWrapper.sol";
 import {ViewStorageAccessible} from "src/contracts/mixins/StorageAccessible.sol";
 
 contract StorageAccessibleTest is Test {

--- a/test/reader/StorageAccessibleWrapper.sol
+++ b/test/reader/StorageAccessibleWrapper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity >=0.7.6 <0.9.0;
+pragma solidity ^0.8.0;
 
 import "src/contracts/mixins/StorageAccessible.sol";
 

--- a/test/reader/StorageReadable.t.sol
+++ b/test/reader/StorageReadable.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-pragma solidity >=0.7.6 <0.9.0;
-pragma abicoder v2;
+pragma solidity ^0.8.0;
 
 import {Test} from "forge-std/Test.sol";
-import {StorageAccessibleWrapper} from "test/src/vendor/StorageAccessibleWrapper.sol";
+
+import {StorageAccessibleWrapper} from "./StorageAccessibleWrapper.sol";
 
 contract StorageReadableTest is Test {
     StorageAccessibleWrapper instance;

--- a/test/reader/ViewStorageAccessible.t.sol
+++ b/test/reader/ViewStorageAccessible.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-
-pragma solidity >=0.7.6 <0.9.0;
-pragma abicoder v2;
+pragma solidity ^0.8.0;
 
 import {Test} from "forge-std/Test.sol";
-import {StorageAccessibleWrapper, ExternalStorageReader} from "test/src/vendor/StorageAccessibleWrapper.sol";
+
 import {ViewStorageAccessible} from "src/contracts/mixins/StorageAccessible.sol";
+
+import {StorageAccessibleWrapper, ExternalStorageReader} from "./StorageAccessibleWrapper.sol";
 
 contract StorageAccessibleTest is Test {
     StorageAccessibleWrapper instance;


### PR DESCRIPTION
## Description

Since it's now only used by new tests. `StorageAccessibleWrapper.sol` can be moved away from `test/src/` (folder which should disappear at some point anyway).

Because of this, I also updated Solidity pragmas. I was lenient with the version (`^0.8.0`) because there's no need to enforce restrictive versions for tests. I had to lower the pragmas in tests when I suspected a compiler regression and wanted to test it, and this was avoidably annoying.

## Test Plan

CI.
