### PR TITLE
chore: make CI fail on solc warnings

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -9,6 +9,12 @@ optimizer = true
 optimizer_runs = 1000000
 evm_version = "cancun"
 
+deny_warnings = true
+ignored_warnings_from = [
+  "src/contracts/test/SmartSellOrder.sol",
+  "test/src/SmartSellOrder.sol"
+]
+
 fs_permissions = [
   { access = "read", path = "./balancer"},
   { access = "read", path = "./networks.json"},

--- a/foundry.toml
+++ b/foundry.toml
@@ -10,10 +10,6 @@ optimizer_runs = 1000000
 evm_version = "cancun"
 
 deny_warnings = true
-ignored_warnings_from = [
-  "src/contracts/test/SmartSellOrder.sol",
-  "test/src/SmartSellOrder.sol"
-]
 
 fs_permissions = [
   { access = "read", path = "./balancer"},

--- a/test/GPv2AllowListAuthenticator/IsSolver.sol
+++ b/test/GPv2AllowListAuthenticator/IsSolver.sol
@@ -12,7 +12,7 @@ contract IsSolver is Helper {
         assertTrue(authenticator.isSolver(solver));
     }
 
-    function test_returns_false_when_given_address_is_not_a_recognized_solver() public {
+    function test_returns_false_when_given_address_is_not_a_recognized_solver() public view {
         assertFalse(authenticator.isSolver(solver));
     }
 

--- a/test/src/SmartSellOrder.sol
+++ b/test/src/SmartSellOrder.sol
@@ -1,5 +1,3 @@
-// TODO when removing this file: remove paths from list of ignored warnings.
-
 // SPDX-License-Identifier: LGPL-3.0-or-later
 pragma solidity >=0.7.6 <0.9.0;
 pragma abicoder v2;
@@ -61,7 +59,6 @@ contract SmartSellOrder is EIP1271Verifier {
         if (balance != 0) {
             sellToken.safeTransfer(owner, balance);
         }
-        selfdestruct(payable(owner));
     }
 
     function isValidSignature(bytes32 hash, bytes memory signature)

--- a/test/src/SmartSellOrder.sol
+++ b/test/src/SmartSellOrder.sol
@@ -1,3 +1,5 @@
+// TODO when removing this file: remove paths from list of ignored warnings.
+
 // SPDX-License-Identifier: LGPL-3.0-or-later
 pragma solidity >=0.7.6 <0.9.0;
 pragma abicoder v2;


### PR DESCRIPTION
## Description

Because compiled contracts are cached locally, a warning is only seen when compiling a contract that was just modified.
This means it's easy to let compiler warnings slip through unnoticed from development into the actual PR.

This PR:
1. makes `forge build` fail if a compiler warning is encountered;
2. ~silences a known warning that won't be fixed (use of deprecated `selfdestruct` in tests);~ remove selfdestruct in a test, since it's just there as an optional gas efficiency feature but it doesn't serve any other purpose;
3. fixes a residual compiler warning.

~~About the silencing: I'd like to specify exactly where to locate the silenced warning in the code, but the Solidity compiler doesn't let you (see for example [ethereum/solidity](https://github.com/ethereum/solidity) issue 2691 and 2675).
Foundry lets you ignore solc warning, but it's less fine-grained. In theory it's possible to ignore specific warning reasons, but the selfdestruct one isn't among the [supported ignored warnings](https://book.getfoundry.sh/reference/config/solidity-compiler#ignored_error_codes). Also, I think it's a good warning to have and I wouldn't want to disable it outside of tests.~~

## Test Plan

CI. You can also introduce a warning and notice that `forge build` returns exit status `1`.
