### PR TITLE
chore: sort imports

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -18,6 +18,7 @@ fs_permissions = [
 ]
 
 [fmt]
+sort_imports = true
 ignore = [
   # We don't want to change the formatting of our main contracts until the
   # migration to Foundry is concluded.

--- a/script/TransferOwnership.s.sol
+++ b/script/TransferOwnership.s.sol
@@ -5,7 +5,7 @@ import {console} from "forge-std/Script.sol";
 
 import {GPv2AllowListAuthentication} from "../src/contracts/GPv2AllowListAuthentication.sol";
 
-import {ERC173, ERC165} from "./interfaces/ERC173.sol";
+import {ERC165, ERC173} from "./interfaces/ERC173.sol";
 import {NetworksJson} from "./lib/NetworksJson.sol";
 
 contract TransferOwnership is NetworksJson {

--- a/test/GPv2AllowListAuthenticator/InitializeManager.t.sol
+++ b/test/GPv2AllowListAuthenticator/InitializeManager.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8;
 
 import {GPv2AllowListAuthentication} from "src/contracts/GPv2AllowListAuthentication.sol";
 
-import {Helper, GPv2AllowListAuthenticationHarness} from "./Helper.sol";
+import {GPv2AllowListAuthenticationHarness, Helper} from "./Helper.sol";
 
 contract InitializeManager is Helper {
     function test_should_initialize_the_manager() public view {

--- a/test/GPv2Signing/Helper.sol
+++ b/test/GPv2Signing/Helper.sol
@@ -2,9 +2,9 @@
 pragma solidity ^0.8;
 
 import {IERC20} from "src/contracts/interfaces/IERC20.sol";
-import {GPv2Signing} from "src/contracts/mixins/GPv2Signing.sol";
 import {GPv2Order} from "src/contracts/libraries/GPv2Order.sol";
 import {GPv2Trade} from "src/contracts/libraries/GPv2Trade.sol";
+import {GPv2Signing} from "src/contracts/mixins/GPv2Signing.sol";
 
 // solhint-disable func-name-mixedcase
 contract Harness is GPv2Signing {

--- a/test/GPv2VaultRelayer/BatchSwapWithFee.FeeTransfer.t.sol
+++ b/test/GPv2VaultRelayer/BatchSwapWithFee.FeeTransfer.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import {GPv2Transfer, IERC20, IVault, GPv2Transfer, GPv2Order} from "src/contracts/GPv2VaultRelayer.sol";
+import {GPv2Order, GPv2Transfer, GPv2Transfer, IERC20, IVault} from "src/contracts/GPv2VaultRelayer.sol";
 
 import {BatchSwapWithFeeHelper} from "./Helper.sol";
 

--- a/test/GPv2VaultRelayer/BatchSwapWithFee.t.sol
+++ b/test/GPv2VaultRelayer/BatchSwapWithFee.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import {IERC20, IVault, GPv2Transfer, GPv2Order} from "src/contracts/GPv2VaultRelayer.sol";
+import {GPv2Order, GPv2Transfer, IERC20, IVault} from "src/contracts/GPv2VaultRelayer.sol";
 
 import {BatchSwapWithFeeHelper} from "./Helper.sol";
 

--- a/test/GPv2VaultRelayer/Helper.sol
+++ b/test/GPv2VaultRelayer/Helper.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8;
 
 import {Test} from "forge-std/Test.sol";
 
-import {GPv2VaultRelayer, IVault, IERC20, GPv2Order, GPv2Transfer} from "src/contracts/GPv2VaultRelayer.sol";
+import {GPv2Order, GPv2Transfer, GPv2VaultRelayer, IERC20, IVault} from "src/contracts/GPv2VaultRelayer.sol";
 
 contract Helper is Test {
     address payable internal creator = payable(makeAddr("GPv2VaultRelayer.Helper creator"));

--- a/test/GPv2VaultRelayer/TransferFromAccounts.t.sol
+++ b/test/GPv2VaultRelayer/TransferFromAccounts.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 pragma solidity ^0.8;
 
-import {IERC20, IVault, GPv2Transfer, GPv2Order} from "src/contracts/GPv2VaultRelayer.sol";
+import {GPv2Order, GPv2Transfer, IERC20, IVault} from "src/contracts/GPv2VaultRelayer.sol";
 
 import {Helper} from "./Helper.sol";
 

--- a/test/libraries/Bytecode.sol
+++ b/test/libraries/Bytecode.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 pragma solidity ^0.8;
 
-import {Vm} from "forge-std/Test.sol";
 import {Bytes} from "./Bytes.sol";
+import {Vm} from "forge-std/Test.sol";
 
 library Bytecode {
     using Bytes for bytes;

--- a/test/libraries/Order.sol
+++ b/test/libraries/Order.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 pragma solidity ^0.8;
 
-import {IERC20, GPv2Order} from "src/contracts/libraries/GPv2Order.sol";
+import {GPv2Order, IERC20} from "src/contracts/libraries/GPv2Order.sol";
 import {GPv2Trade} from "src/contracts/libraries/GPv2Trade.sol";
 
 library Order {

--- a/test/libraries/Settlement.sol
+++ b/test/libraries/Settlement.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 pragma solidity ^0.8;
 
-import {GPv2Settlement} from "src/contracts/GPv2Settlement.sol";
 import {SettlementEncoder} from "./encoders/SettlementEncoder.sol";
 import {SwapEncoder} from "./encoders/SwapEncoder.sol";
+import {GPv2Settlement} from "src/contracts/GPv2Settlement.sol";
 
 library Settlement {
     function settle(GPv2Settlement settler, SettlementEncoder.EncodedSettlement memory settlement) internal {

--- a/test/libraries/Sign.sol
+++ b/test/libraries/Sign.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8;
 
 import {Vm} from "forge-std/Test.sol";
 
-import {GPv2Order, GPv2Trade, GPv2Signing, EIP1271Verifier} from "src/contracts/mixins/GPv2Signing.sol";
+import {EIP1271Verifier, GPv2Order, GPv2Signing, GPv2Trade} from "src/contracts/mixins/GPv2Signing.sol";
 
 import {Bytes} from "./Bytes.sol";
 

--- a/test/libraries/Trade.sol
+++ b/test/libraries/Trade.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 pragma solidity ^0.8;
 
-import {IERC20, GPv2Order, GPv2Trade, GPv2Signing} from "src/contracts/mixins/GPv2Signing.sol";
-import {Sign} from "./Sign.sol";
 import {Order} from "./Order.sol";
+import {Sign} from "./Sign.sol";
+import {GPv2Order, GPv2Signing, GPv2Trade, IERC20} from "src/contracts/mixins/GPv2Signing.sol";
 
 library Trade {
     using GPv2Trade for uint256;

--- a/test/libraries/encoders/SettlementEncoder.sol
+++ b/test/libraries/encoders/SettlementEncoder.sol
@@ -4,12 +4,12 @@ pragma solidity ^0.8;
 import {Vm} from "forge-std/Test.sol";
 
 import {
-    IERC20,
-    GPv2Order,
-    GPv2Trade,
-    GPv2Signing,
     GPv2Interaction,
-    GPv2Settlement
+    GPv2Order,
+    GPv2Settlement,
+    GPv2Signing,
+    GPv2Trade,
+    IERC20
 } from "src/contracts/GPv2Settlement.sol";
 
 import {Sign} from "../Sign.sol";

--- a/test/libraries/encoders/SwapEncoder.sol
+++ b/test/libraries/encoders/SwapEncoder.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8;
 
 import {Vm} from "forge-std/Test.sol";
 
-import {IERC20, IVault, GPv2Order, GPv2Trade, GPv2Signing} from "src/contracts/GPv2Settlement.sol";
+import {GPv2Order, GPv2Signing, GPv2Trade, IERC20, IVault} from "src/contracts/GPv2Settlement.sol";
 
 import {Sign} from "../Sign.sol";
 import {Trade} from "../Trade.sol";

--- a/test/libraries/encoders/TokenRegistry.sol
+++ b/test/libraries/encoders/TokenRegistry.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 pragma solidity ^0.8;
 
-import {IERC20, GPv2Order} from "src/contracts/libraries/GPv2Order.sol";
+import {GPv2Order, IERC20} from "src/contracts/libraries/GPv2Order.sol";
 
 type Registry is bytes32;
 

--- a/test/reader/StorageAccessible.t.sol
+++ b/test/reader/StorageAccessible.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 pragma solidity ^0.8;
 
+import {ExternalStorageReader, StorageAccessibleWrapper} from "./StorageAccessibleWrapper.sol";
 import {Test, Vm} from "forge-std/Test.sol";
-import {StorageAccessibleWrapper, ExternalStorageReader} from "./StorageAccessibleWrapper.sol";
 import {ViewStorageAccessible} from "src/contracts/mixins/StorageAccessible.sol";
 
 contract StorageAccessibleTest is Test {

--- a/test/reader/ViewStorageAccessible.t.sol
+++ b/test/reader/ViewStorageAccessible.t.sol
@@ -5,7 +5,7 @@ import {Test} from "forge-std/Test.sol";
 
 import {ViewStorageAccessible} from "src/contracts/mixins/StorageAccessible.sol";
 
-import {StorageAccessibleWrapper, ExternalStorageReader} from "./StorageAccessibleWrapper.sol";
+import {ExternalStorageReader, StorageAccessibleWrapper} from "./StorageAccessibleWrapper.sol";
 
 contract StorageAccessibleTest is Test {
     StorageAccessibleWrapper instance;

--- a/test/script/TransferOwnership.t.sol
+++ b/test/script/TransferOwnership.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8;
 
 import {Test} from "forge-std/Test.sol";
 
-import {TransferOwnership, ERC173} from "script/TransferOwnership.s.sol";
+import {ERC173, TransferOwnership} from "script/TransferOwnership.s.sol";
 import {ERC165} from "script/interfaces/ERC173.sol";
 import {GPv2AllowListAuthentication} from "src/contracts/GPv2AllowListAuthentication.sol";
 

--- a/test/src/SmartSellOrder.sol
+++ b/test/src/SmartSellOrder.sol
@@ -3,12 +3,12 @@
 pragma solidity >=0.7.6 <0.9.0;
 pragma abicoder v2;
 
+import "src/contracts/GPv2Settlement.sol";
 import "src/contracts/interfaces/GPv2EIP1271.sol";
 import "src/contracts/interfaces/IERC20.sol";
 import "src/contracts/libraries/GPv2Order.sol";
 import "src/contracts/libraries/GPv2SafeERC20.sol";
 import "src/contracts/libraries/SafeMath.sol";
-import "src/contracts/GPv2Settlement.sol";
 
 /// @title Proof of Concept Smart Order
 /// @author Gnosis Developers


### PR DESCRIPTION
## Description

Today I learned about Foundry's [`sort_imports`](https://book.getfoundry.sh/reference/config/formatter?highlight=sort_imports#sort_imports) fmt configuration option.

As it has almost zero dev cost to use it, I'd go for it.

Drawback: I noticed a bug while formatting our code, specifically this section:
```solidity
import {IERC20} from "src/contracts/interfaces/IERC20.sol";
import {GPv2Signing} from "src/contracts/mixins/GPv2Signing.sol";
import {GPv2Order} from "src/contracts/libraries/GPv2Order.sol";
import {GPv2Trade} from "src/contracts/libraries/GPv2Trade.sol";
```
was changed to:
```solidity
import {IERC20} from "src/contracts/interfaces/IERC20.sol";

import {GPv2Order} from "src/contracts/libraries/GPv2Order.sol";
import {GPv2Trade} from "src/contracts/libraries/GPv2Trade.sol";
import {GPv2Signing} from "src/contracts/mixins/GPv2Signing.sol";
```

and I had to manually remove the extra newline.
I'd still say this isn't a big issue as we'd notice on reviewing.

## Test Plan

CI doesn't fail on `fmt --check`.