### PR TITLE
chore: merkle.io for ETH RPC

### DIFF
--- a/test/e2e/Helper.sol
+++ b/test/e2e/Helper.sol
@@ -77,7 +77,7 @@ abstract contract Helper is Test {
             try vm.envString("FORK_URL") returns (string memory url) {
                 forkUrl = url;
             } catch {
-                forkUrl = "https://eth.llamarpc.com";
+                forkUrl = "https://eth.merkle.io";
             }
 
             forkId = vm.createSelectFork(forkUrl, blockNumber);


### PR DESCRIPTION
## Description

This PR replaces llamarpc with merkle.io for the RPC as there are higher RPS.

## Test Plan

1. Ensure CI/CD remains green for fork tests.

## Related Issues

N/A