### PR TITLE
chore: remove env

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,10 +31,6 @@ jobs:
 
     name: Foundry project
     runs-on: ubuntu-latest
-    env:
-      # should support archive requests
-      FORK_URL: 'https://eth.llamarpc.com'
-      FORK_BLOCK_NUMBER: 20691292
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Description

This PR addresses the environment setup that was used for fork tests. Now, the `FORK_URL` is set by a secret, and the `FORK_BLOCK_NUMBER` is hard coded within the `e2e` Helper as a constant so that assumptions are visible for auditors / developers.

## Test Plan

1. Confirm CI/CD green

## Related Issues

N/A