### PR TITLE
Add placeholder action to publish to NPM

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+# This is a placeholder GitHub Action with the sole purpose of making this
+# action appear on the Action interface. It isn't supposed to be executed on
+# the current branch, only on the `v1` branch.
+# Related discussion: https://github.com/github/docs/issues/31007
+
+name: Publish package to NPM
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Print warning
+        run: echo 'Publishing this branch to NPM is not supported'
+      - name: Make the action fail
+        run: exit 1


### PR DESCRIPTION
## Description

Commit 0bdf44c256dcce32f5ba299154d6155c09bc0e9e removes the GitHub Action to publish to NPM.

This action is supposed to be available only on branch `v1`, however GitHub requires `workflow_dispatch` actions to appear on the default branch in order to be triggered through the [Action overview page](https://github.com/cowprotocol/contracts/actions). From the [docs](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onworkflow_dispatch):

> This trigger only receives events when the workflow file is on the default branch.
 
This PR creates a no-op action that would make it possible to trigger the action with the same name on `v1`.
There appear to be [workarounds](https://stackoverflow.com/questions/63362126/github-actions-how-can-i-run-a-workflow-created-on-a-non-master-branch-from-t/71057825#71057825) to not pollute the default branch, however the approach of recreating the action on `main` seems less likely to break in the future.

## Test Plan

Compare with [the corresponding action on `v1`](https://github.com/cowprotocol/contracts/blob/v1/.github/workflows/publish.yml) and confirm that the name and references are the same.