### PR TITLE
Add Etherscan configuration for new networks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowprotocol/contracts",
-  "version": "2.1.0-alpha",
+  "version": "2.0.0-alpha",
   "license": "LGPL-3.0-or-later",
   "private": true,
   "repository": {


### PR DESCRIPTION
## Description

Add the necessary configuration lines for allowing contract verification on the Block explorers of the networks introduced in #239.
BNB was already verified. Optimism and Polygon just worked out of the box. Avalanche defaults to [Snowtrace](https://snowtrace.io/), so I had to include a custom configuration for that network in order to use [SnowScan](https://snowscan.xyz/) and used:

```sh
npx hardhat verify --network avalanche 0x9E7Ae8Bdba9AA346739792d219a808884996Db67
npx hardhat verify --network avalanche 0x9008D19f58AAbD9eD0D60971565AA8510560ab41 0x2c4c28DDBdAc9C5E7055b4C863b72eA0149D8aFE 0xBA12222222228d8Ba445958a75a0704d566BF2C8
```

I also enabled Sourcify because why not?

## Test Plan

Check out the contract addresses on the block explorer.