### PR TITLE
chore(ci): harden

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/add-action-project.yml
+++ b/.github/workflows/add-action-project.yml
@@ -10,7 +10,7 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.3.0
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: https://github.com/orgs/cowprotocol/projects/8
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,24 +7,15 @@ on:
 
 jobs:
   test:
-    strategy:
-      matrix:
-        node-version: [18.x]
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          node-version: ${{ matrix.node }}
-      - id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v4
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ matrix.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ matrix.os }}-yarn-
+          node-version: 18.x
+          cache: yarn
       - run: yarn --frozen-lockfile
       - run: yarn build
       - run: yarn lint

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.6.1
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/gas.yml
+++ b/.github/workflows/gas.yml
@@ -27,23 +27,19 @@ jobs:
   gas:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
+          persist-credentials: false
 
-      - uses: actions/setup-node@v4
-      - id: yarn-cache
-        run: echo "dir=$(yarn cache dir)"  >> "$GITHUB_OUTPUT"
-      - uses: actions/cache@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            yarn-
+          cache: yarn
+
       - run: yarn --frozen-lockfile
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de # v1.4.0
         with:
           version: nightly
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,18 +16,16 @@ env:
 
 jobs:
   lint:
-    strategy:
-      fail-fast: true
-
     name: Foundry project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de # v1.4.0
         with:
           version: nightly
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
       - name: Print warning
         run: echo 'Publishing this branch to NPM is not supported'
       - name: Make the action fail

--- a/.github/workflows/review-check.yml
+++ b/.github/workflows/review-check.yml
@@ -3,6 +3,8 @@ name: Enforce Review Rules
 on:
   pull_request:
     types: [opened, edited, synchronize]
+    paths:
+      - "src/contracts/**"
 
 jobs:
   enforce-review-rules:
@@ -10,31 +12,14 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Check if PR modifies specific path
-      shell: bash
-      id: check-path
-      run: |
-        BASE_SHA=$(jq -r .pull_request.base.sha < $GITHUB_EVENT_PATH)
-        HEAD_SHA=$(jq -r .pull_request.head.sha < $GITHUB_EVENT_PATH)
-        git fetch origin $BASE_SHA $HEAD_SHA
-        files=$(git diff --name-only $BASE_SHA $HEAD_SHA | tr '\n' ' ')
-        echo "files=$files" >> $GITHUB_OUTPUT
-        if echo "$files" | grep -q 'src/contracts/'; then
-          echo "specific_path=true" >> $GITHUB_OUTPUT
-        else
-          echo "specific_path=false" >> $GITHUB_OUTPUT
-        fi
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
 
     - name: Ensure required reviewers
       shell: bash
       id: ensure-reviewers
       run: |
-        GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-        PR_NUMBER=${{ github.event.pull_request.number }}
-        REPO=${{ github.repository }}
-        
         # Fetch approved and non-dismissed reviews of the PR
         REVIEWERS=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
                     "https://api.github.com/repos/$REPO/pulls/$PR_NUMBER/reviews" \
@@ -48,15 +33,17 @@ jobs:
         NUM_REVIEWERS=$(echo "$REVIEWERS" | wc -w)
 
         # Check review requirements
-        if [ "${{ steps.check-path.outputs.specific_path }}" == "true" ]; then
-          if [ "$NUM_REVIEWERS" -lt 2 ]; then
-            echo "Insufficient reviewers for src/contracts/ path. Required: 2 reviewers."
-            echo "review_check_passed=false" >> $GITHUB_OUTPUT
-            exit 1
-          fi
+        if [ "$NUM_REVIEWERS" -lt 2 ]; then
+          echo "Insufficient reviewers for src/contracts/ path. Required: 2 reviewers."
+          echo "review_check_passed=false" >> $GITHUB_OUTPUT
+          exit 1
         fi
 
         echo "review_check_passed=true" >> $GITHUB_OUTPUT
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
 
     - name: Success message
       if: steps.ensure-reviewers.outputs.review_check_passed == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,23 +32,19 @@ jobs:
     name: Foundry project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
+          persist-credentials: false
 
-      - uses: actions/setup-node@v4
-      - id: yarn-cache
-        run: echo "dir=$(yarn cache dir)"  >> "$GITHUB_OUTPUT"
-      - uses: actions/cache@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            yarn-
+          cache: yarn
+
       - run: yarn --frozen-lockfile
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de # v1.4.0
         with:
           version: nightly
 
@@ -56,15 +52,14 @@ jobs:
         # We always build with 0.7.6 to ensure that the project is compatible with the oldest version
         run: |
           forge --version
-          if [ "${{ matrix.profile }}" == "solc-0.7.6" ]; then
-            FOUNDRY_PROFILE=ci forge build --sizes --use 0.7.6 --skip 'test/*' --skip 'script/*'
+          if [ "$PROFILE" == "solc-0.7.6" ]; then
+            forge build --sizes --use 0.7.6 --skip 'test/*' --skip 'script/*'
           else
-            FOUNDRY_PROFILE=ci forge build --sizes
+            forge build --sizes
           fi
-        id: build
+        env:
+          PROFILE: ${{ matrix.profile }}
 
       - name: Run Forge tests
         if: matrix.profile != 'solc-0.7.6'
-        run: |
-          FOUNDRY_PROFILE=ci forge test -vvv
-        id: test
+        run: forge test -vvv


### PR DESCRIPTION
This PR hardens the CI by explicitly pinning all GitHub actions to their exact commit SHAs. Additionally, it enables Dependabot for future upgrades + security alerts.