### PR TITLE
fix(ci): lock foundry version

### DIFF
--- a/.github/workflows/gas.yml
+++ b/.github/workflows/gas.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: v1.3.5
 
       - name: Check gas snapshots
         run: forge snapshot --check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: v1.3.5
 
       - name: Check Forge fmt
         run: forge fmt --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: v1.3.5
 
       - name: Run Forge build with ${{ matrix.profile }}
         # We always build with 0.7.6 to ensure that the project is compatible with the oldest version


### PR DESCRIPTION
now that foundry has stable releases, there is no reason to subject ourselves to the instability of the nightly releases. this PR proposes locking to the current foundry release v1.3.5, and we can manually bump it as it makes sense.

as it so happens, the current nightly release seems to be changing the lint rules or something and the CI is currently failing with `main` branch code.
